### PR TITLE
254 post the system must support bulk posts of item lines records based on specified conditions

### DIFF
--- a/Cargohub/controllers/itemlinecontroller.cs
+++ b/Cargohub/controllers/itemlinecontroller.cs
@@ -65,7 +65,7 @@ public class ItemLineController : ControllerBase
 
     // PUT: api/itemLine/5
     [HttpPut("{id}")]
-    public ActionResult UpdateItemLine(int id, [FromBody] ItemLineCS itemLine)
+    public ActionResult<ItemLineCS> UpdateItemLine(int id, [FromBody] ItemLineCS itemLine)
     {
         if (id != itemLine.Id)
         {

--- a/Cargohub/controllers/itemlinecontroller.cs
+++ b/Cargohub/controllers/itemlinecontroller.cs
@@ -25,7 +25,7 @@ public class ItemLineController : ControllerBase
         return Ok(itemLine);
     }
 
-    // GET: api/itemLine/5
+    // GET: api/itemlines/5
     [HttpGet("{id}")]
     public ActionResult<ItemLineCS> GetItemLineById(int id)
     {
@@ -37,22 +37,35 @@ public class ItemLineController : ControllerBase
         return Ok(itemLine);
     }
 
-    // POST: api/itemLine
+    // POST: api/itemines
     [HttpPost]
-    public async Task<ActionResult<ItemLineCS>> AddItemLine([FromBody] ItemLineCS newItemLine)
+    public IActionResult AddItemLine([FromBody] ItemLineCS newItemLine)
     {
         if (newItemLine == null)
         {
             return BadRequest("ItemLine is null.");
         }
 
-        var createdItemLine = await _itemLineService.AddItemLine(newItemLine);
+        var createdItemLine = _itemLineService.AddItemLine(newItemLine);
         return CreatedAtAction(nameof(GetItemLineById), new { id = createdItemLine.Id }, createdItemLine);
+    }
+
+    // POST: /itemlines/multiple
+    [HttpPost("multiple")]
+    public ActionResult<ItemLineCS> CreateMultipleItemLines([FromBody] List<ItemLineCS> newItemLines)
+    {
+        if (newItemLines is null)
+        {
+            return BadRequest("Item line data is null");
+        }
+
+        var createdItemLines = _itemLineService.CreateMultipleItemLines(newItemLines);
+        return StatusCode(StatusCodes.Status201Created, createdItemLines);
     }
 
     // PUT: api/itemLine/5
     [HttpPut("{id}")]
-    public async Task<ActionResult<ItemLineCS>> UpdateItemLine(int id, [FromBody] ItemLineCS itemLine)
+    public ActionResult UpdateItemLine(int id, [FromBody] ItemLineCS itemLine)
     {
         if (id != itemLine.Id)
         {
@@ -65,7 +78,7 @@ public class ItemLineController : ControllerBase
             return NotFound();
         }
 
-        var updatedItemLine = await _itemLineService.UpdateItemLine(id, itemLine);
+        var updatedItemLine = _itemLineService.UpdateItemLine(id, itemLine);
         return Ok(updatedItemLine);
     }
 

--- a/Cargohub/services/Iitemlineservices.cs
+++ b/Cargohub/services/Iitemlineservices.cs
@@ -6,8 +6,9 @@ public interface IItemLineService
 {
     List<ItemLineCS> GetAllItemlines();
     ItemLineCS GetItemLineById(int id);
-    Task<ItemLineCS> AddItemLine(ItemLineCS newItemType);
-    Task<ItemLineCS> UpdateItemLine(int id, ItemLineCS itemLine);
+    ItemLineCS AddItemLine(ItemLineCS newItemType);
+    List<ItemLineCS> CreateMultipleItemLines(List<ItemLineCS>newItemLine);
+    ItemLineCS UpdateItemLine(int id, ItemLineCS itemLine);
     void DeleteItemLine(int id);
     List<ItemCS> GetItemsByItemLineId(int itemlineId);
     void DeleteItemLines(List<int> ids);

--- a/Cargohub/services/itemlineservices.cs
+++ b/Cargohub/services/itemlineservices.cs
@@ -34,9 +34,11 @@ public class ItemLineService : IItemLineService
     }
 
     // Method to add a new item
-    public async Task<ItemLineCS> AddItemLine(ItemLineCS newItemLine)
+    public ItemLineCS AddItemLine(ItemLineCS newItemLine)
     {
         List<ItemLineCS> items = GetAllItemlines();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         // Auto-increment ID
         if (items.Any())
@@ -47,17 +49,29 @@ public class ItemLineService : IItemLineService
         {
             newItemLine.Id = 1;
         }
-
+        newItemLine.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newItemLine.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         items.Add(newItemLine);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);
-        await File.WriteAllTextAsync("data/item_lines.json", jsonData);
+        File.WriteAllText("data/item_lines.json", jsonData);
 
         return newItemLine;
     }
 
+    public List<ItemLineCS> CreateMultipleItemLines(List<ItemLineCS>newItemLines)
+    {
+        List<ItemLineCS> addedItemLines = new List<ItemLineCS>();
+        foreach(ItemLineCS itemLine in newItemLines)
+        {
+            ItemLineCS addItemLine = AddItemLine(itemLine);
+            addedItemLines.Add(addItemLine);
+        }
+        return addedItemLines;
+    }
+
     // Method to update an item
-    public async Task<ItemLineCS> UpdateItemLine(int id, ItemLineCS itemLine)
+    public ItemLineCS UpdateItemLine(int id, ItemLineCS itemLine)
     {
         List<ItemLineCS> items = GetAllItemlines();
         var existingItem = items.FirstOrDefault(i => i.Id == id);
@@ -77,7 +91,7 @@ public class ItemLineService : IItemLineService
         existingItem.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);
-        await File.WriteAllTextAsync("data/item_lines.json", jsonData);
+        File.WriteAllText("data/item_lines.json", jsonData);
 
         return existingItem;
     }

--- a/tests/itemgroupsTests.cs
+++ b/tests/itemgroupsTests.cs
@@ -82,10 +82,10 @@ namespace itemgroup.Tests
 
             // Act
             var result = _itemGroupController.CreateItemGroup(newItemGroup);
-
-            // Assert
             var createdResult = result as CreatedAtActionResult;
             var returnedItem = createdResult.Value as ItemGroupCS;
+
+            // Assert
             Assert.IsNotNull(createdResult);
             Assert.AreEqual(newItemGroup.Name, returnedItem.Name);
         }
@@ -125,10 +125,10 @@ namespace itemgroup.Tests
 
             // Act
             var value = _itemGroupController.UpdateItemGroup(1, updatedItemGroup);
-
-            // Assert
             var okResult = value.Result as OkObjectResult;
             var returnedItem = okResult.Value as ItemGroupCS;
+
+            // Assert
             Assert.IsNotNull(okResult);
             Assert.AreEqual(updatedItemGroup.Description, returnedItem.Description);
         }

--- a/tests/itemlinetests.cs
+++ b/tests/itemlinetests.cs
@@ -74,78 +74,103 @@ public class ItemLineTests
     }
 
     [TestMethod]
-    public async Task AddItemLineTest_ValidItem()
+    public void AddItemLineTest_ValidItem()
     {
         // Arrange
         var newItemLine = new ItemLineCS { Id = 1, Description = "New Item" };
-        _mockItemLineService.Setup(service => service.AddItemLine(newItemLine)).ReturnsAsync(newItemLine);
+        _mockItemLineService.Setup(service => service.AddItemLine(newItemLine)).Returns(newItemLine);
 
         // Act
-        var value = await _itemLineController.AddItemLine(newItemLine);
+        var value = _itemLineController.AddItemLine(newItemLine);
+        var createdResult = value as CreatedAtActionResult;
+        var returnedItem = createdResult.Value as ItemLineCS;
 
         // Assert
-        var createdResult = value.Result as CreatedAtActionResult;
-        var returnedItem = createdResult.Value as ItemLineCS;
         Assert.IsNotNull(createdResult);
         Assert.AreEqual(newItemLine.Description, returnedItem.Description);
     }
 
     [TestMethod]
-    public async Task AddItemLineTest_NullItem()
+    public void AddItemLineTest_NullItem()
     {
         // Act
-        var value = await _itemLineController.AddItemLine(null);
+        var value = _itemLineController.AddItemLine(null);
+        var createdResult = value as BadRequestObjectResult;
 
         // Assert
-        Assert.IsInstanceOfType(value.Result, typeof(BadRequestObjectResult));
+        Assert.IsInstanceOfType(createdResult, typeof(BadRequestObjectResult));
     }
 
     [TestMethod]
-    public async Task UpdateItemLineTest_ValidItem()
+    public void CreateMultipleWarehouse_ReturnsCreatedResult_WithNewWarehouse()
+    {
+        // Arrange
+        var itemLines = new List<ItemLineCS>
+            {
+                new ItemLineCS { Id = 3, Name = "Group 3", Description = "Cool items" },
+                new ItemLineCS { Id = 4, Name = "Group 4", Description = "Cool items" }
+            };
+        _mockItemLineService.Setup(service => service.CreateMultipleItemLines(itemLines)).Returns(itemLines);
+
+        // Act
+        var result = _itemLineController.CreateMultipleItemLines(itemLines);
+        var createdResult = result.Result as ObjectResult;
+        var returnedItems = createdResult.Value as List<ItemLineCS>;
+        var firstItemLine = returnedItems[0];
+
+        // Assert
+        Assert.IsNotNull(createdResult);
+        Assert.IsNotNull(returnedItems);
+        Assert.AreEqual(itemLines[0].Name, firstItemLine.Name);
+        Assert.AreEqual(itemLines[0].Description, firstItemLine.Description);
+    }
+
+    [TestMethod]
+    public void UpdateItemLineTest_ValidItem()
     {
         // Arrange
         var existingItemLine = new ItemLineCS { Id = 1, Description = "Existing Item" };
         var updatedItemLine = new ItemLineCS { Id = 1, Description = "Updated Item" };
         _mockItemLineService.Setup(service => service.GetItemLineById(1)).Returns(existingItemLine);
-        _mockItemLineService.Setup(service => service.UpdateItemLine(1, updatedItemLine)).ReturnsAsync(updatedItemLine);
+        _mockItemLineService.Setup(service => service.UpdateItemLine(1, updatedItemLine)).Returns(updatedItemLine);
 
         // Act
-        var value = await _itemLineController.UpdateItemLine(1, updatedItemLine);
-
-        // Assert
+        var value = _itemLineController.UpdateItemLine(1, updatedItemLine);
         var okResult = value.Result as OkObjectResult;
         var returnedItem = okResult.Value as ItemLineCS;
+
+        // Assert
         Assert.IsNotNull(okResult);
         Assert.AreEqual(updatedItemLine.Description, returnedItem.Description);
     }
 
     [TestMethod]
-    public async Task UpdateItemLineTest_WrongId()
+    public void UpdateItemLineTest_WrongId()
     {
         // Arrange
         var updatedItemLine = new ItemLineCS { Id = 1, Description = "Updated Item" };
         _mockItemLineService.Setup(service => service.GetItemLineById(1)).Returns((ItemLineCS)null);
 
         // Act
-        var value = await _itemLineController.UpdateItemLine(1, updatedItemLine);
+        var value = _itemLineController.UpdateItemLine(1, updatedItemLine);
 
         // Assert
         Assert.IsInstanceOfType(value.Result, typeof(NotFoundResult));
     }
 
     [TestMethod]
-    public async Task UpdateItemLineTest_IdMismatch()
+    public void UpdateItemLineTest_IdMismatch()
     {
         // Arrange
         var updatedItemLine = new ItemLineCS { Id = 2, Description = "Updated Item" };
 
         // Act
-        var value = await _itemLineController.UpdateItemLine(1, updatedItemLine);
+        var value = _itemLineController.UpdateItemLine(1, updatedItemLine);
 
         // Assert
         Assert.IsInstanceOfType(value.Result, typeof(BadRequestResult));
     }
-    
+
     [TestMethod]
     public void DeleteItemLineTest_Exists()
     {
@@ -202,9 +227,10 @@ public class ItemLineTests
         Assert.IsInstanceOfType(value.Result, typeof(NotFoundResult));
     }
     [TestMethod]
-    public void DeleteItemLinesTest_Succes(){
+    public void DeleteItemLinesTest_Succes()
+    {
         //Arrange
-        var idstodel = new List<int>(){1, 2, 3};
+        var idstodel = new List<int>() { 1, 2, 3 };
         //Act
         var result = _itemLineController.DeleteItemLines(idstodel);
         var resultok = result as OkObjectResult;


### PR DESCRIPTION
ItemLineController.cs added the CreateMultipleItemLines function and cleaned up some asyncs
IItemLineService.cs added the CreateMultipleItemLines to the interface
ItemLineService.cs added the CreateMultipleItemLines function and cleaned up the asyncs and made it so that AddItemLines now takes the current date for created_At
ItemLineTests.cs Added the CreateMultipleWarehouse_ReturnsCreatedResult_WithNewWarehouse and fixed some tests that weren't working because of the async removals