### PR TITLE
Add GetLatestUpdatedWarehouse endpoint and service method with role-b…

### DIFF
--- a/V2/Cargohub/controllers/warehousecontroller.cs
+++ b/V2/Cargohub/controllers/warehousecontroller.cs
@@ -171,4 +171,24 @@ public class WarehouseController : ControllerBase
         _warehouseService.DeleteWarehouses(ids);
         return Ok("Deleted warehouses");
     }
+
+    // GET: /warehouses/latest
+    [HttpGet("latest")]
+    public ActionResult<WarehouseCS> GetLatestUpdatedWarehouse()
+    {
+        List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager", "Sales", "Analyst", "Logistics" };
+        var userRole = HttpContext.Items["UserRole"]?.ToString();
+
+        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        {
+            return Unauthorized();
+        }
+
+        var latestWarehouse = _warehouseService.GetLatestUpdatedWarehouse();
+        if (latestWarehouse is null)
+        {
+            return NotFound();
+        }
+        return Ok(latestWarehouse);
+    }
 }

--- a/V2/Cargohub/services/Iwarehouseservice.cs
+++ b/V2/Cargohub/services/Iwarehouseservice.cs
@@ -10,4 +10,5 @@ public interface IWarehouseService
     WarehouseCS PatchWarehouse(int id, string property, object value);
     void DeleteWarehouse(int id);
     void DeleteWarehouses(List<int> ids);
+    List<WarehouseCS> GetLatestUpdatedWarehouse(int count = 5);
 }

--- a/V2/Cargohub/services/warehouseservice.cs
+++ b/V2/Cargohub/services/warehouseservice.cs
@@ -164,4 +164,10 @@ public class WarehouseService : IWarehouseService
         var json = JsonConvert.SerializeObject(warehouses, Formatting.Indented);
         File.WriteAllText(_path, json);
     }
+
+    public List<WarehouseCS> GetLatestUpdatedWarehouse(int count = 5)
+    {
+        var allWarehouses = GetAllWarehouses();
+        return allWarehouses.OrderByDescending(warehouse => warehouse.updated_at).Take(count).ToList();
+    }
 }

--- a/V2/tests/warehouseTest.cs
+++ b/V2/tests/warehouseTest.cs
@@ -320,6 +320,55 @@ namespace TestsV2
             Assert.IsInstanceOfType(result, typeof(OkObjectResult));
             Assert.AreEqual(resultok.StatusCode, 200);
         }
+
+        [TestMethod]
+        public void GetLatestUpdatedWarehouseTest_Success()
+        {
+            // Arrange
+            var warehouse = new WarehouseCS { Id = 1, Address = "Straat 1" };
+            _mockWarehouseService.Setup(service => service.GetLatestUpdatedWarehouse(It.IsAny<int>())).Returns(new List<WarehouseCS> { warehouse });
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _warehouseController.GetLatestUpdatedWarehouse();
+
+            // Assert
+            var okResult = result.Result as OkObjectResult;
+            var returnedItems = (okResult.Value as IEnumerable<WarehouseCS>)?.FirstOrDefault();
+            Assert.IsNotNull(okResult);
+            Assert.IsNotNull(returnedItems);
+            Assert.AreEqual(warehouse.Address, returnedItems.Address);
+        }
+
+        [TestMethod]
+        public void GetLatestUpdatedWarehouseTest_Failed()
+        {
+            // Arrange
+            _mockWarehouseService.Setup(service => service.GetLatestUpdatedWarehouse(It.IsAny<int>())).Returns((List<WarehouseCS>)null);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _warehouseController.GetLatestUpdatedWarehouse();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
     }
 }
 


### PR DESCRIPTION
This pull request introduces a new feature to retrieve the latest updated warehouses and includes corresponding updates to the service interface, service implementation, and unit tests. The most important changes are summarized below:

### New Feature: Retrieve Latest Updated Warehouses

* [`V2/Cargohub/controllers/warehousecontroller.cs`](diffhunk://#diff-83013da75da1cf8f6f89d899ecdd9ce1a400f38e904d8eea22bef703b7d3eb15R174-R193): Added a new endpoint `GetLatestUpdatedWarehouse` which returns the latest updated warehouses based on user roles.

### Service Interface Update

* [`V2/Cargohub/services/Iwarehouseservice.cs`](diffhunk://#diff-6c277314cfe5e159362722efcc6e00277973cf78556a0c309be6ca5dde47ce9eR13): Added a new method `GetLatestUpdatedWarehouse` to the `IWarehouseService` interface.

### Service Implementation Update

* [`V2/Cargohub/services/warehouseservice.cs`](diffhunk://#diff-01b167a29e4992e12024b46270ded340fddf3ca3d365de021593be9425d02307R167-R172): Implemented the `GetLatestUpdatedWarehouse` method to return the latest updated warehouses sorted by the `updated_at` property.

### Unit Tests

* [`V2/tests/warehouseTest.cs`](diffhunk://#diff-ebc0138d0226a44770899ebfebdfe809e9cc02dae0409e4e41f0c7d875815072R323-R371): Added unit tests `GetLatestUpdatedWarehouseTest_Success` and `GetLatestUpdatedWarehouseTest_Failed` to verify the new endpoint functionality.