### PR TITLE
Add GetLatestTransfers endpoint and service method with role-based ac…

### DIFF
--- a/V2/Cargohub/controllers/transfercontroller.cs
+++ b/V2/Cargohub/controllers/transfercontroller.cs
@@ -201,4 +201,21 @@ public class TransferController : ControllerBase
         _transferService.DeleteTransfers(ids);
         return Ok("deleted transfers");
     }
+
+    // GET: /transfers/latest
+    [HttpGet("latest")]
+    public ActionResult<IEnumerable<TransferCS>> GetLatestTransfers()
+    {
+        List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager",
+                                                                "Analyst", "Supervisor", "Operative" };
+        var userRole = HttpContext.Items["UserRole"]?.ToString();
+
+        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        {
+            return Unauthorized();
+        }
+
+        var latestTransfers = _transferService.GetLatestTransfers();
+        return Ok(latestTransfers);
+    }
 }

--- a/V2/Cargohub/services/Itransferservice.cs
+++ b/V2/Cargohub/services/Itransferservice.cs
@@ -11,4 +11,5 @@ public interface ITransferService
     TransferCS CommitTransfer(int id);
     void DeleteTransfer(int id);
     void DeleteTransfers(List<int> ids);
+    List<TransferCS> GetLatestTransfers(int count = 5);
 }

--- a/V2/Cargohub/services/transferservice.cs
+++ b/V2/Cargohub/services/transferservice.cs
@@ -168,4 +168,11 @@ public class TransferService : ITransferService
         var json = JsonConvert.SerializeObject(transfers, Formatting.Indented);
         File.WriteAllText(_path, json);
     }
+
+    public List<TransferCS> GetLatestTransfers(int count = 5)
+    {
+        List<TransferCS> transfers = GetAllTransfers();
+        return transfers.OrderByDescending(t => t.updated_at).Take(count).ToList();
+    }
+
 }

--- a/V2/tests/TransfersTests.cs
+++ b/V2/tests/TransfersTests.cs
@@ -397,6 +397,36 @@ public void DeleteWarehouseTest_Success()
             Assert.IsInstanceOfType(result, typeof(OkObjectResult));
             Assert.AreEqual(resultok.StatusCode, 200);
         }
+
+        [TestMethod]
+        public void GetLatestTransfersTest()
+        {
+            //arrange
+            var transfers = new List<TransferCS>
+            {
+                new TransferCS { Id = 1, Reference = "JoJo", transfer_from = 9292, transfer_to = null, transfer_status = "completed", created_at = default, updated_at = default, Items = new List<ItemIdAndAmount> ()},
+                new TransferCS { Id = 2, Reference = "JoJo part 2", transfer_from = null, transfer_to = 1, transfer_status = "processing", created_at = default, updated_at = default, Items = new List<ItemIdAndAmount> ()}
+            };
+            _mockTransferService.Setup(service => service.GetLatestTransfers(5)).Returns(transfers);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _transferController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //Act
+            var value = _transferController.GetLatestTransfers();
+            var okResult = value.Result as OkObjectResult;
+            var returnedItems = okResult.Value as IEnumerable<TransferCS>;
+
+            //Assert
+            Assert.IsNotNull(okResult);
+            Assert.AreEqual(2, returnedItems.Count());
+        }
     }
 }
 


### PR DESCRIPTION
This pull request introduces a new feature to retrieve the latest transfers and includes corresponding changes in the `TransferController`, `ITransferService`, `TransferService`, and test files. The most important changes are summarized below:

### New Feature: Retrieve Latest Transfers

* **Controller Update**:
  - Added a new endpoint `GET: /transfers/latest` in `TransferController` to retrieve the latest transfers. This includes role-based access control to ensure only authorized roles can access this endpoint.

* **Service Interface Update**:
  - Introduced a new method `GetLatestTransfers` in the `ITransferService` interface to define the contract for retrieving the latest transfers.

* **Service Implementation Update**:
  - Implemented the `GetLatestTransfers` method in the `TransferService` class to fetch and return the latest transfers sorted by the `updated_at` timestamp.

* **Unit Test Addition**:
  - Added a new unit test `GetLatestTransfersTest` in the `TransfersTests` class to verify the functionality of the new `GetLatestTransfers` endpoint and ensure it returns the expected results.