### PR TITLE
333 the system must allow a user to upload a csv or json file to import their data

### DIFF
--- a/V2/Cargohub/Program.cs
+++ b/V2/Cargohub/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddTransient<IShipmentService, ShipmentService>();
 builder.Services.AddTransient<ISupplierService, SupplierService>();
 builder.Services.AddTransient<ITransferService, TransferService>();
 builder.Services.AddTransient<IOrderService, OrderService>();
+builder.Services.AddTransient<IAdminService, AdminService>();
 
 var app = builder.Build();
 

--- a/V2/Cargohub/controllers/admincontroller.cs
+++ b/V2/Cargohub/controllers/admincontroller.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using ServicesV2;
+
+namespace ControllersV2;
+
+[ApiController]
+[Route("api/v2/admin")]
+public class AdminController : ControllerBase
+{
+    // private readonly IAdminService _adminservice;
+    // public AdminController(IAdminService adminservice)
+    // {
+    //     _adminservice = adminservice;
+    // }
+    public AdminController()
+    {
+    }
+    // POST: /AddData. this is a function that is used to add data to the data folder. it can recieve either be a .json or .csv file. but when the function is going to save the file, it will save it as a .json file.
+    [HttpPost("AddData")]
+    public IActionResult AddData([FromForm] IFormFile file)
+    {
+        // Log incoming form data for debugging
+    var form = HttpContext.Request.Form;
+    foreach (var key in form.Keys)
+    {
+        Console.WriteLine($"Key: {key}, Value: {form[key]}");
+    }
+
+    // Check for file binding issues
+    if (file == null)
+    {
+        return BadRequest(new { error = "File is not being recognized. Ensure the key is 'file'." });
+    }
+
+    return Ok("File successfully received.");
+        // // Allowed roles
+        // List<string> listOfAllowedRoles = new List<string>() { "Admin" };
+        // var userRole = HttpContext.Items["UserRole"]?.ToString();
+
+        // // Authorization check
+        // if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        // {
+        //     return Unauthorized("You are not authorized to upload data.");
+        // }
+
+        // // Check if the file is provided
+        // if (file == null || file.Length == 0)
+        // {
+        //     return BadRequest(new { error = "The file field is required and cannot be empty." });
+        // }
+
+        // try
+        // {
+        //     // Ensure it's saved as .json
+        //     var saveFileName = Path.ChangeExtension(file.FileName, ".json");
+        //     var path = Path.Combine(Directory.GetCurrentDirectory(), "Data", saveFileName);
+
+        //     // Save the file
+        //     using (var stream = new FileStream(path, FileMode.Create))
+        //     {
+        //         file.CopyTo(stream);
+        //     }
+
+        //     return Ok(new { message = "File uploaded and saved successfully as JSON.", fileName = saveFileName });
+        // }
+        // catch (Exception ex)
+        // {
+        //     return StatusCode(500, new { error = "An error occurred while saving the file.", details = ex.Message });
+        // }
+    }
+
+}

--- a/V2/Cargohub/controllers/admincontroller.cs
+++ b/V2/Cargohub/controllers/admincontroller.cs
@@ -7,14 +7,12 @@ namespace ControllersV2;
 [Route("api/v2/admin")]
 public class AdminController : ControllerBase
 {
-    // private readonly IAdminService _adminservice;
-    // public AdminController(IAdminService adminservice)
-    // {
-    //     _adminservice = adminservice;
-    // }
-    public AdminController()
+    private readonly IAdminService _adminservice;
+    public AdminController(IAdminService adminservice)
     {
+        _adminservice = adminservice;
     }
+   
     // POST: /AddData. this is a function that is used to add data to the data folder. it can recieve either be a .json or .csv file. but when the function is going to save the file, it will save it as a .json file.
     [HttpPost("AddData")]
     public IActionResult AddData([FromForm] IFormFile file)
@@ -35,43 +33,19 @@ public class AdminController : ControllerBase
             return BadRequest(new { error = "The file field is required and cannot be empty." });
         }
 
+        if (Path.GetExtension(file.FileName) != ".json"&& Path.GetExtension(file.FileName) != ".csv")
+        {
+            return BadRequest(new { error = "The file must be either a .json or .csv file." });
+        }
+
+
+
         try
         {
-            // Read CSV content
-            using var reader = new StreamReader(file.OpenReadStream());
-            var csvContent = reader.ReadToEnd();
+            var filename = _adminservice.AddData(file);
+           
 
-            // Parse CSV into JSON format
-            var lines = csvContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-            var headers = lines[0].Split(',');
-
-            var clients = new List<Dictionary<string, string>>();
-
-            for (int i = 1; i < lines.Length; i++)
-            {
-                var values = lines[i].Split(',');
-                var client = new Dictionary<string, string>();
-
-                for (int j = 0; j < headers.Length; j++)
-                {
-                    client[headers[j].Trim()] = values[j].Trim();
-                }
-
-                clients.Add(client);
-            }
-
-            var jsonContent = System.Text.Json.JsonSerializer.Serialize(clients, new System.Text.Json.JsonSerializerOptions
-            {
-                WriteIndented = true
-            });
-
-            // Save as JSON file
-            var saveFileName = Path.ChangeExtension(file.FileName, ".json");
-            var path = Path.Combine(Directory.GetCurrentDirectory(), "Data", saveFileName);
-
-            System.IO.File.WriteAllText(path, jsonContent);
-
-            return Ok(new { message = "File uploaded, converted, and saved successfully as JSON.", fileName = saveFileName });
+            return Ok(new { message = "File uploaded, converted, and saved successfully as JSON.", filename });
         }
         catch (Exception ex)
         {

--- a/V2/Cargohub/services/Iadminservice.cs
+++ b/V2/Cargohub/services/Iadminservice.cs
@@ -1,0 +1,6 @@
+namespace ServicesV2;
+
+public interface IAdminService
+{
+
+}

--- a/V2/Cargohub/services/Iadminservice.cs
+++ b/V2/Cargohub/services/Iadminservice.cs
@@ -2,5 +2,5 @@ namespace ServicesV2;
 
 public interface IAdminService
 {
-
+    string AddData(IFormFile file);
 }

--- a/V2/Cargohub/services/adminservice.cs
+++ b/V2/Cargohub/services/adminservice.cs
@@ -1,0 +1,58 @@
+using Newtonsoft.Json;
+
+namespace ServicesV2;
+
+public class AdminService : IAdminService
+{
+    public AdminService()
+    {
+    }
+    public string AddData(IFormFile file)
+    {
+        
+        var path = Path.Combine(Directory.GetCurrentDirectory(), "Data", file.FileName);
+
+        if (Path.GetExtension(file.FileName) == ".json")
+        {
+
+            using (var stream = new FileStream(path, FileMode.Create))
+            {
+                file.CopyTo(stream);
+            }
+
+            return file.FileName;
+        }
+        using var reader = new StreamReader(file.OpenReadStream());
+        var csvContent = reader.ReadToEnd();
+
+        // Parse CSV into JSON format
+        var lines = csvContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var headers = lines[0].Split(',');
+
+        var clients = new List<Dictionary<string, string>>();
+
+        for (int i = 1; i < lines.Length; i++)
+        {
+            var values = lines[i].Split(',');
+            var client = new Dictionary<string, string>();
+
+            for (int j = 0; j < headers.Length; j++)
+            {
+                client[headers[j].Trim()] = values[j].Trim();
+            }
+
+            clients.Add(client);
+        }
+
+        var jsonContent = System.Text.Json.JsonSerializer.Serialize(clients, new System.Text.Json.JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        // Save as JSON file
+        var saveFileName = Path.Combine(Directory.GetCurrentDirectory(), "Data", Path.ChangeExtension(file.FileName, ".json"));
+        System.IO.File.WriteAllText(saveFileName, jsonContent);
+        return saveFileName;
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a new feature to handle admin data uploads in the `V2/Cargohub` project. The changes include adding a new service and controller to support uploading and processing `.json` and `.csv` files, converting them to `.json` format, and saving them.

### New Feature: Admin Data Upload

* **Service Registration**:
  * Added `IAdminService` and `AdminService` to the service container in `Program.cs`.

* **Admin Controller**:
  * Created `AdminController` with an endpoint to handle file uploads, perform authorization checks, and validate file types. The endpoint processes `.json` and `.csv` files, converting and saving them as `.json`.

* **Admin Service Interface**:
  * Defined the `IAdminService` interface with a method for adding data from an uploaded file.

* **Admin Service Implementation**:
  * Implemented the `AdminService` class, which includes logic to save `.json` files directly and convert `.csv` files to `.json` before saving.