### PR TITLE
334 implimenteer een filter voor item

### DIFF
--- a/V2/Cargohub/controllers/itemcontroller.cs
+++ b/V2/Cargohub/controllers/itemcontroller.cs
@@ -17,9 +17,9 @@ public class ItemController : ControllerBase
         _itemService = itemService;
         _inventoryService = inventoryService;
     }
-    //filter for get all items
-    [HttpGet("searchterm?={term}")]
-    public ActionResult<List<ItemCS>> Filter([FromRoute] string? searchterm){
+    //Apply pageination to get allitems()
+    [HttpGet("pageinated")]
+    public ActionResult Pageination([FromQuery] string page, [FromQuery] string pageSize){
         List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager", "Inventory Manager",
                                                                    "Floor Manager", "Sales", "Analyst", "Logistics" };
         var userRole = HttpContext.Items["UserRole"]?.ToString();
@@ -28,26 +28,29 @@ public class ItemController : ControllerBase
         {
             return Unauthorized();
         }
-        if(!string.IsNullOrWhiteSpace(searchterm.ToString())){
-            List<ItemCS> items = _itemService.GetAllItems();
-            var filtered = items.Where(_=>_.code.Contains(searchterm.ToString())|| 
-            _.commodity_code.Contains(searchterm.ToString())|| 
-            // _.item_group == (int)searchterm ||
-            // _.item_line == (int)searchterm ||
-            // _.item_type == (int)searchterm ||
-            _.model_number.Contains(searchterm.ToString())||
-            // _.pack_order_quantity == (int)searchterm ||
-            _.supplier_code.Contains(searchterm.ToString())||
-            // _.supplier_id == (int)searchterm ||
-            _.supplier_part_number.Contains(searchterm.ToString())||
-            _.uid == searchterm.ToString() ||
-            // _.unit_order_quantity == (int)searchterm ||
-            // _.unit_purchase_quantity == (int)searchterm ||
-            _.upc_code.Contains(searchterm.ToString())).OrderBy(_=>_.updated_at).ToList();
-            return Ok(filtered);
-        }
-        return BadRequest();
+
+        var items = _itemService.GetAllItems();
+
+        int pageInt = int.TryParse(page, out int result) ? result : 1;
+        int pageSizeInt = int.TryParse(pageSize, out int result1) ? result1 : 10;
+
+        var itemsCount = items.Count();
+        var totalpages = (int)Math.Ceiling(itemsCount / (double) pageSizeInt);
+
+        var index = (pageInt - 1) * pageSizeInt;
+        var pageItems = items.Skip(index).Take(pageSizeInt).ToList();
+
+        var result2 = new {
+            Page = pageInt,
+            pagesize = pageSizeInt,
+            TotalItems = itemsCount,
+            TotalPages = totalpages,
+            Data = pageItems
+        };
+
+        return Ok(result2);
     }
+    
     // GET: items
     // Retrieves all items
     [HttpGet()]

--- a/V2/Cargohub/controllers/itemcontroller.cs
+++ b/V2/Cargohub/controllers/itemcontroller.cs
@@ -86,7 +86,7 @@ public class ItemController : ControllerBase
             var index1 = (page - 1) * pageSize;
             var filteredpageItems = itemsToFilter.Skip(index1).Take(pageSize).ToList();
 
-            var result1 = new PageinationCS(){ Page=page, PageSize=pageSize, TotItems=totalPages, Data=filteredpageItems};
+            var result1 = new PaginationCS(){ Page=page, PageSize=pageSize, TotItems=totalPages, Data=filteredpageItems};
             return Ok(result1);
         }
         int itemsCount = items.Count();

--- a/V2/Cargohub/controllers/itemcontroller.cs
+++ b/V2/Cargohub/controllers/itemcontroller.cs
@@ -3,13 +3,7 @@ using System.Collections.Generic;
 using ServicesV2;
 
 namespace ControllersV2;
-public class Pageination()
-{
-    public int Page {get; set;}
-    public int PageSize {get;set;}
-    public int TotItems {get;set;}
-    public List<ItemCS>? Data {get; set;}
-}
+
 public class itemFilter()
 {
     public string? code { get; set; }
@@ -92,7 +86,7 @@ public class ItemController : ControllerBase
             var index1 = (page - 1) * pageSize;
             var filteredpageItems = itemsToFilter.Skip(index1).Take(pageSize).ToList();
 
-            var result1 = new Pageination(){ Page=page, PageSize=pageSize, TotItems=totalPages, Data=filteredpageItems};
+            var result1 = new PageinationCS(){ Page=page, PageSize=pageSize, TotItems=totalPages, Data=filteredpageItems};
             return Ok(result1);
         }
         int itemsCount = items.Count();

--- a/V2/Cargohub/controllers/itemcontroller.cs
+++ b/V2/Cargohub/controllers/itemcontroller.cs
@@ -17,7 +17,37 @@ public class ItemController : ControllerBase
         _itemService = itemService;
         _inventoryService = inventoryService;
     }
+    //filter for get all items
+    [HttpGet("searchterm?={term}")]
+    public ActionResult<List<ItemCS>> Filter([FromRoute] string? searchterm){
+        List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager", "Inventory Manager",
+                                                                   "Floor Manager", "Sales", "Analyst", "Logistics" };
+        var userRole = HttpContext.Items["UserRole"]?.ToString();
 
+        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        {
+            return Unauthorized();
+        }
+        if(!string.IsNullOrWhiteSpace(searchterm.ToString())){
+            List<ItemCS> items = _itemService.GetAllItems();
+            var filtered = items.Where(_=>_.code.Contains(searchterm.ToString())|| 
+            _.commodity_code.Contains(searchterm.ToString())|| 
+            // _.item_group == (int)searchterm ||
+            // _.item_line == (int)searchterm ||
+            // _.item_type == (int)searchterm ||
+            _.model_number.Contains(searchterm.ToString())||
+            // _.pack_order_quantity == (int)searchterm ||
+            _.supplier_code.Contains(searchterm.ToString())||
+            // _.supplier_id == (int)searchterm ||
+            _.supplier_part_number.Contains(searchterm.ToString())||
+            _.uid == searchterm.ToString() ||
+            // _.unit_order_quantity == (int)searchterm ||
+            // _.unit_purchase_quantity == (int)searchterm ||
+            _.upc_code.Contains(searchterm.ToString())).OrderBy(_=>_.updated_at).ToList();
+            return Ok(filtered);
+        }
+        return BadRequest();
+    }
     // GET: items
     // Retrieves all items
     [HttpGet()]

--- a/V2/Cargohub/controllers/itemcontroller.cs
+++ b/V2/Cargohub/controllers/itemcontroller.cs
@@ -104,7 +104,79 @@ public class ItemController : ControllerBase
         };
         return Ok(result2);
     }
+    /* 
+    ik wilde het als een normale httpget maar dat breekt dan de test voor gewoon getallitems endpoint (niet service) dus het is in httpget("page")
+    ik laat het hier just in case
+    [HttpGet("")]
+    public ActionResult<IEnumerable<ItemCS>> GetAllItems([FromQuery] itemFilter tofilter, [FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+    {
+        List<string> listOfAllowedRoles = new List<string>()
+        { "Admin", "Warehouse Manager", "Inventory Manager", "Floor Manager", "Sales", "Analyst", "Logistics" };
+        var userRole = HttpContext.Items["UserRole"]?.ToString();
 
+        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        {
+            return Unauthorized();
+        }
+
+        var items = _itemService.GetAllItems();
+        var itemsquery = items.AsQueryable();
+        if (tofilter.GetType().GetProperties().All(prop => prop.GetValue(tofilter) != null))
+        {
+            var itemsToFilter = items.AsQueryable();
+            if (!string.IsNullOrEmpty(tofilter.code))
+            {
+                itemsToFilter = itemsToFilter.Where(_ => _.code == tofilter.code);
+            }
+            if (!string.IsNullOrEmpty(tofilter.commodity_code))
+            {
+                itemsToFilter = itemsToFilter.Where(_ => _.commodity_code == tofilter.commodity_code);
+            }
+            if (!string.IsNullOrEmpty(tofilter.upc_code))
+            {
+                itemsToFilter = itemsToFilter.Where(_ => _.upc_code == tofilter.upc_code);
+            }
+            if (!string.IsNullOrEmpty(tofilter.model_number))
+            {
+                itemsToFilter = itemsToFilter.Where(_ => _.model_number == tofilter.model_number);
+            }
+            if (tofilter.item_line.HasValue && tofilter.item_line > 0)
+            {
+                itemsToFilter = itemsToFilter.Where(_ => _.item_line == tofilter.item_line);
+            }
+            if (tofilter.item_group.HasValue && tofilter.item_group > 0)
+            {
+                itemsToFilter = itemsToFilter.Where(_ => _.item_group == tofilter.item_group);
+            }
+            if (tofilter.item_type.HasValue && tofilter.item_type > 0)
+            {
+                itemsToFilter = itemsToFilter.Where(_ => _.item_type == tofilter.item_type);
+            }
+            var filtereditemsCount = itemsToFilter.Count();
+            int totalPages = (int)Math.Ceiling(filtereditemsCount / (double)pageSize);
+
+            var index1 = (page - 1) * pageSize;
+            var filteredpageItems = itemsToFilter.Skip(index1).Take(pageSize).ToList();
+
+            var result1 = new PageinationCS(){ Page=page, PageSize=pageSize, TotItems=totalPages, Data=filteredpageItems};
+            return Ok(result1);
+        }
+        int itemsCount = items.Count();
+        int pagetotal = (int)Math.Ceiling(itemsCount / (double)pageSize);
+
+        var index = (page - 1) * pageSize;
+        var pageItems = itemsquery.Skip(index).Take(pageSize).ToList();
+        var result2 = new
+        {
+            Page = page,
+            PageSize = pageSize,
+            TotalItems = itemsCount,
+            TotalPages = pagetotal,
+            Data = pageItems
+        };
+        return Ok(result2);
+    }
+    */
     // GET: items
     // Retrieves all items
     [HttpGet()]

--- a/V2/Cargohub/models/page.cs
+++ b/V2/Cargohub/models/page.cs
@@ -1,4 +1,4 @@
-public class PageinationCS()
+public class PaginationCS()
 {
     public int Page {get; set;}
     public int PageSize {get;set;}

--- a/V2/Cargohub/models/page.cs
+++ b/V2/Cargohub/models/page.cs
@@ -1,0 +1,7 @@
+public class PageinationCS()
+{
+    public int Page {get; set;}
+    public int PageSize {get;set;}
+    public int TotItems {get;set;}
+    public List<ItemCS>? Data {get; set;}
+}


### PR DESCRIPTION
This pull request introduces several significant changes to the `V2/Cargohub` project, focusing on adding filtering and pagination capabilities to the item retrieval endpoint, as well as improving code readability and structure.

### Enhancements to Item Retrieval:

* Added a new `itemFilter` class with various nullable properties to support filtering items based on multiple criteria in `itemcontroller.cs`.
* Introduced a new `GetAllItems` method with pagination and filtering capabilities, ensuring only authorized roles can access the endpoint.

### Code Structure Improvements:

* Added a new `PaginationCS` class  in the models folder to encapsulate pagination details, improving the structure and readability of the response.
* I wanted the implementation as a normal httpget() but that would break the test for it and i didn't want do that without  without telling everyone so that's been commented out. please do inform me if i am allowed to refactor the the test for it, because the ActionResult.Result.value is a instance of PaginationCS instead of List<ItemCS>