### PR TITLE
filter plus pagination werkt

### DIFF
--- a/V2/Cargohub/controllers/shipmentcontroller.cs
+++ b/V2/Cargohub/controllers/shipmentcontroller.cs
@@ -5,6 +5,27 @@ using ServicesV2;
 
 namespace ControllersV2;
 
+public class shipmentFilter
+{
+    // public int Id { get; set; }
+    public int order_id { get; set; }
+    public int source_id { get; set; }
+    public DateTime order_date { get; set; }
+    public DateTime request_date { get; set; }
+    public DateTime shipment_date { get; set; }
+    public string? shipment_type { get; set; }
+    public string? shipment_status { get; set; }
+    public string? carrier_code { get; set; }
+    public string? service_code { get; set; }
+    public string? payment_type { get; set; }
+    public string? transfer_mode { get; set; }
+    public int total_package_count { get; set; }
+    public double total_package_weight { get; set; }
+    // public List<ItemIdAndAmount> Items { get; set; }
+    // public DateTime created_at { get; set; }
+    // public DateTime updated_at { get; set; }
+}
+
 [ApiController]
 [Route("api/v2/shipments")]
 public class ShipmentController : ControllerBase
@@ -31,6 +52,96 @@ public class ShipmentController : ControllerBase
 
         var shipments = _shipmentService.GetAllShipments();
         return Ok(shipments);
+    }
+    [HttpGet("page")]
+    public ActionResult<PaginationCS<ShipmentCS>> GetAllShipments(
+        [FromQuery] shipmentFilter tofilter, 
+        [FromQuery] int page = 1, 
+        [FromQuery] int pageSize = 10)
+    {
+        List<string> listOfAllowedRoles = new List<string>()
+        { "Admin", "Warehouse Manager", "Inventory Manager", "Floor Manager", "Sales", "Analyst", "Logistics" };
+        var userRole = HttpContext.Items["UserRole"]?.ToString();
+
+        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        {
+            return Unauthorized();
+        }
+
+        var items = _shipmentService.GetAllShipments();
+        var query = items.AsQueryable();
+
+        // Apply filters
+        if (tofilter.order_id != 0)
+        {
+            query = query.Where(x => x.order_id == tofilter.order_id);
+        }
+        if (tofilter.source_id != 0)
+        {
+            query = query.Where(x => x.source_id == tofilter.source_id);
+        }
+        if (tofilter.order_date != DateTime.MinValue)
+        {
+            query = query.Where(x => x.order_date == tofilter.order_date);
+        }
+        if (tofilter.request_date != DateTime.MinValue)
+        {
+            query = query.Where(x => x.request_date == tofilter.request_date);
+        }
+        if (tofilter.shipment_date != DateTime.MinValue)
+        {
+            query = query.Where(x => x.shipment_date == tofilter.shipment_date);
+        }
+        if (tofilter.shipment_type != null)
+        {
+            query = query.Where(x => x.shipment_type == tofilter.shipment_type);
+        }
+        if (tofilter.shipment_status != null)
+        {
+            query = query.Where(x => x.shipment_status == tofilter.shipment_status);
+        }
+        if (tofilter.carrier_code != null)
+        {
+            query = query.Where(x => x.carrier_code == tofilter.carrier_code);
+        }
+        if (tofilter.service_code != null)
+        {
+            query = query.Where(x => x.service_code == tofilter.service_code);
+        }
+        if (tofilter.payment_type != null)
+        {
+            query = query.Where(x => x.payment_type == tofilter.payment_type);
+        }
+        if (tofilter.transfer_mode != null)
+        {
+            query = query.Where(x => x.transfer_mode == tofilter.transfer_mode);
+        }
+        if (tofilter.total_package_count != 0)
+        {
+            query = query.Where(x => x.total_package_count >= tofilter.total_package_count);
+        }
+        if (tofilter.total_package_weight != 0)
+        {
+            query = query.Where(x => x.total_package_weight >= tofilter.total_package_weight);
+        }
+
+        // Get the filtered count
+        int filteredShipmentsCount = query.Count();
+
+        // Pagination logic
+        int totalPages = (int)Math.Ceiling(filteredShipmentsCount / (double)pageSize);
+        var pagedShipments = query.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+
+        // Return paginated and filtered result
+        var result = new PaginationCS<ShipmentCS>()
+        {
+            Page = page,
+            PageSize = pageSize,
+            TotalPages = totalPages,
+            Data = pagedShipments
+        };
+
+        return Ok(result);
     }
 
     // GET: /shipments/{id}


### PR DESCRIPTION
This pull request introduces a new filtering and pagination feature to the `ShipmentController` in the `V2/Cargohub` module. The main changes include the addition of a `shipmentFilter` class and a new endpoint to handle filtered and paginated shipment data.

### Enhancements to ShipmentController:

* Added `shipmentFilter` class: This class includes various properties such as `order_id`, `source_id`, `order_date`, `request_date`, `shipment_date`, `shipment_type`, `shipment_status`, `carrier_code`, `service_code`, `payment_type`, `transfer_mode`, `total_package_count`, and `total_package_weight` to facilitate filtering of shipments.

* New endpoint for filtered and paginated shipments: Introduced a new `GetAllShipments` method that accepts a `shipmentFilter` object and pagination parameters (`page` and `pageSize`). This method filters the shipments based on the provided criteria and returns a paginated result.