### PR TITLE
working functionality

### DIFF
--- a/PythonTests/test_warehouses.py
+++ b/PythonTests/test_warehouses.py
@@ -38,13 +38,23 @@ class TestClass(unittest.TestCase):
         ]
         self.headers = {'Api-Key': 'AdminKey'}
 
-    def test_get_warehouses(self):
-        for version in self.versions:
+    def test_get_warehouses_v1(self):
+        for version in ["http://localhost:5001/api/v1"]:
             with self.subTest(version=version):
                 response = self.warehouse.get(
                     url=(version + "/warehouses"), headers=self.headers
                 )
                 self.assertEqual(response.status_code, 200)
+                self.assertEqual(type(response.json()), list)
+
+    def test_get_warehouses_v2(self):
+        for version in ["http://localhost:5002/api/v2"]:
+            with self.subTest(version=version):
+                response = self.warehouse.get(
+                    url=(version + "/warehouses"), headers=self.headers
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(type(response.json()), dict)
 
     def test_get_warehouse_id(self):
         for version in self.versions:

--- a/V2/Cargohub/controllers/warehousecontroller.cs
+++ b/V2/Cargohub/controllers/warehousecontroller.cs
@@ -31,25 +31,26 @@ public class WarehouseController : ControllerBase
     }
 
     // GET: /warehouses
+    // [HttpGet()]
+    // public ActionResult<IEnumerable<WarehouseCS>> GetAllWarehouses()
+    // {
+    //     List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager", "Sales", "Analyst", "Logistics" };
+    //     var userRole = HttpContext.Items["UserRole"]?.ToString();
+
+    //     if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+    //     {
+    //         return Unauthorized();
+    //     }
+
+    //     var warehouses = _warehouseService.GetAllWarehouses();
+    //     if (warehouses is null)
+    //     {
+    //         return NotFound();
+    //     }
+    //     return Ok(warehouses);
+    // }
+    //example route /warehouses?City=Amsterdam
     [HttpGet()]
-    public ActionResult<IEnumerable<WarehouseCS>> GetAllWarehouses()
-    {
-        List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager", "Sales", "Analyst", "Logistics" };
-        var userRole = HttpContext.Items["UserRole"]?.ToString();
-
-        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
-        {
-            return Unauthorized();
-        }
-
-        var warehouses = _warehouseService.GetAllWarehouses();
-        if (warehouses is null)
-        {
-            return NotFound();
-        }
-        return Ok(warehouses);
-    }
-    [HttpGet("page")]
     public ActionResult<PaginationCS<WarehouseCS>> GetAllWarehouses(
         [FromQuery] warehouseFilter tofilter, 
         [FromQuery] int page = 1, 
@@ -64,6 +65,9 @@ public class WarehouseController : ControllerBase
             return Unauthorized();
         }
         // Filter logic
+        if(tofilter == null){
+            tofilter = new warehouseFilter();
+        }
         var warehouses = _warehouseService.GetAllWarehouses();
         var query = warehouses.AsQueryable();
         if (tofilter.Id != 0)

--- a/V2/tests/warehouseTest.cs
+++ b/V2/tests/warehouseTest.cs
@@ -42,13 +42,13 @@ namespace TestsV2
             };
 
             // Act
-            var result = _warehouseController.GetAllWarehouses();
+            var result = _warehouseController.GetAllWarehouses(null, 1, 10);
 
             // Assert
             var okResult = result.Result as OkObjectResult;
-            var returnedItems = okResult.Value as IEnumerable<WarehouseCS>;
+            var returnedItems = okResult.Value as PaginationCS<WarehouseCS>;
             Assert.IsNotNull(okResult);
-            Assert.AreEqual(2, returnedItems.Count());
+            Assert.AreEqual(2, returnedItems.Data.Count());
         }
 
         [TestMethod]


### PR DESCRIPTION
This pull request includes changes to both the Python tests and the C# controller for the warehouse service. The main goals are to update the test cases to handle different API versions and to modify the controller to support pagination and filtering.

### Python Tests Updates:
* [`PythonTests/test_warehouses.py`](diffhunk://#diff-66c0d65d7fbde9f56762ea4b0409b3903f8c1e51140744fe1f3e4ca11d6c17b2L41-R57): Split the `test_get_warehouses` method into two separate methods, `test_get_warehouses_v1` and `test_get_warehouses_v2`, to test API versions v1 and v2 respectively. The v1 test expects a list response, while the v2 test expects a dictionary response.

### C# Controller Modifications:
* [`V2/Cargohub/controllers/warehousecontroller.cs`](diffhunk://#diff-83013da75da1cf8f6f89d899ecdd9ce1a400f38e904d8eea22bef703b7d3eb15R34-L52): Commented out the original `GetAllWarehouses` method and added a new `GetAllWarehouses` method with pagination and filtering capabilities. This new method accepts `warehouseFilter` and pagination parameters.
* [`V2/Cargohub/controllers/warehousecontroller.cs`](diffhunk://#diff-83013da75da1cf8f6f89d899ecdd9ce1a400f38e904d8eea22bef703b7d3eb15R68-R70): Added a check to initialize `tofilter` if it is null before applying filtering logic.

### C# Test Updates:
* [`V2/tests/warehouseTest.cs`](diffhunk://#diff-ebc0138d0226a44770899ebfebdfe809e9cc02dae0409e4e41f0c7d875815072L45-R51): Updated the `GetWarehousesTest_Exists` test method to call the new `GetAllWarehouses` method with pagination parameters and to assert the count of items in the `Data` property of the pagination result.