### PR TITLE
364 maintenance job on the workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,15 @@ on:
   pull_request:
     branches:
       - '**'
+  schedule:
+    - cron: '0 3 * * *' # Run every day at 3:00 UTC
 
 jobs:
+  nightly-maintenance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove old atrifacts
+        run: rm -rf ./artifacts
   csharp-build-and-test:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This pull request introduces a new scheduled job to the GitHub Actions workflow to perform nightly maintenance. The changes include adding a cron schedule and defining a new job to remove old artifacts.

Changes in GitHub Actions workflow:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R10-R18): Added a cron schedule to run the workflow every day at 3:00 UTC and defined a new job named `nightly-maintenance` to remove old artifacts.