### PR TITLE
Made it so that the python test is logically structured

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: CI and Release
 on:
   push:
     branches:
-      - 'development'
+      - '**'
   pull_request:
     branches:
-      - 'development'
+      - '**'
   schedule:
     - cron: '0 3 * * *' # Run every day at 3:00 UTC
 

--- a/PythonTests/test_Clients.py
+++ b/PythonTests/test_Clients.py
@@ -38,6 +38,37 @@ class TestClass(unittest.TestCase):
     def setUp(self):
         self.client = httpx.Client()
         self.headers = httpx.Headers({'Api-Key': 'AdminKey'})
+    
+    # deze voegt een nieuwe warehouse object
+    def test_04_post_client(self):
+        for version in ["http://localhost:5001/api/v1",
+                        "http://localhost:5002/api/v2"]:
+            with self.subTest(version=version):
+                self.url = f"{version}"
+
+                data = {
+                    "name": "Test Client",
+                    "address": "123 Test Street",
+                    "zip_code": "12345",
+                    "city": "Test City",
+                    "province": "Test Province",
+                    "country": "Test Country",
+                    "contact_phone": "123-456-7890",
+                    "contact_email": "test@example.com",
+                    "created_at": "2023-01-01T00:00:00Z",
+                    "updated_at": "2023-01-01T00:00:00Z"
+                }
+
+                # Stuur de request
+                response = self.client.post(
+                    url=(self.url + "/clients"),
+                    headers=self.headers, json=data)
+
+                # Check de status code
+                self.assertEqual(
+                    response.status_code, 201,
+                    msg=f"Failed to create client: {response.content}"
+                )
 
     def test_01_get_clients(self):
         for version in ["http://localhost:5001/api/v1",
@@ -73,9 +104,20 @@ class TestClass(unittest.TestCase):
             with self.subTest(version=version):
                 self.url = f"{version}"
 
+                # Get the last client ID
+                response = self.client.get(
+                    url=(self.url + "/clients"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get clients: {response.content}"
+                )
+                clients = response.json()
+                last_client_id = clients[-1]["id"] if clients else 1
+
                 # Stuur de request
                 response = self.client.get(
-                    url=(self.url + "/clients/1"), headers=self.headers)
+                    url=(self.url + f"/clients/{last_client_id}"),
+                    headers=self.headers)           
 
                 # Check de status code
                 # Check dat de response een
@@ -94,38 +136,6 @@ class TestClass(unittest.TestCase):
                 # Check dat het client object de juiste properties heeft
                 self.assertTrue(checkClient(response.json()))
 
-    # deze voegt een nieuwe warehouse object
-    def test_04_post_client(self):
-        for version in ["http://localhost:5001/api/v1",
-                        "http://localhost:5002/api/v2"]:
-            with self.subTest(version=version):
-                self.url = f"{version}"
-
-                data = {
-                    "id": 99999,
-                    "name": "Test Client",
-                    "address": "123 Test Street",
-                    "zip_code": "12345",
-                    "city": "Test City",
-                    "province": "Test Province",
-                    "country": "Test Country",
-                    "contact_phone": "123-456-7890",
-                    "contact_email": "test@example.com",
-                    "created_at": "2023-01-01T00:00:00Z",
-                    "updated_at": "2023-01-01T00:00:00Z"
-                }
-
-                # Stuur de request
-                response = self.client.post(
-                    url=(self.url + "/clients"),
-                    headers=self.headers, json=data)
-
-                # Check de status code
-                self.assertEqual(
-                    response.status_code, 201,
-                    msg=f"Failed to create client: {response.content}"
-                )
-
     # Overschrijft een warehouse op basis van de opgegeven warehouse-id
     def test_05_put_client_id(self):
         for version in ["http://localhost:5001/api/v1",
@@ -141,7 +151,7 @@ class TestClass(unittest.TestCase):
                     msg=f"Failed to get clients: {response.content}"
                 )
                 clients = response.json()
-                last_client_id = clients[-1]["id"] if clients else 99999
+                last_client_id = clients[-1]["id"] if clients else 1
 
                 # Create the client if no clients exist
                 if not clients:
@@ -210,9 +220,20 @@ class TestClass(unittest.TestCase):
             with self.subTest(version=version):
                 self.url = f"{version}"
 
+                # Get the last client ID
+                response = self.client.get(
+                    url=(self.url + "/clients"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get clients: {response.content}"
+                )
+                clients = response.json()
+                last_client_id = clients[-1]["id"] if clients else 1
+
                 # Stuur de request
                 response = self.client.delete(
-                    url=(self.url + "/clients/1"), headers=self.headers)
+                    url=(self.url + f"/clients/{last_client_id}"),
+                    headers=self.headers)
 
                 # Check de status code
                 self.assertEqual(response.status_code, 200)

--- a/PythonTests/test_Clients.py
+++ b/PythonTests/test_Clients.py
@@ -40,7 +40,7 @@ class TestClass(unittest.TestCase):
         self.headers = httpx.Headers({'Api-Key': 'AdminKey'})
     
     # deze voegt een nieuwe warehouse object
-    def test_04_post_client(self):
+    def test_01_post_client(self):
         for version in ["http://localhost:5001/api/v1",
                         "http://localhost:5002/api/v2"]:
             with self.subTest(version=version):
@@ -70,7 +70,7 @@ class TestClass(unittest.TestCase):
                     msg=f"Failed to create client: {response.content}"
                 )
 
-    def test_01_get_clients(self):
+    def test_02_get_clients(self):
         for version in ["http://localhost:5001/api/v1",
                         "http://localhost:5002/api/v2"]:
             with self.subTest(version=version):
@@ -98,7 +98,7 @@ class TestClass(unittest.TestCase):
                 # dus niet dat het een list van ints, strings etc. zijn
                 self.assertEqual(type(response.json()[0]), dict)
 
-    def test_02_get_client_id(self):
+    def test_03_get_client_id(self):
         for version in ["http://localhost:5001/api/v1",
                         "http://localhost:5002/api/v2"]:
             with self.subTest(version=version):
@@ -137,7 +137,7 @@ class TestClass(unittest.TestCase):
                 self.assertTrue(checkClient(response.json()))
 
     # Overschrijft een warehouse op basis van de opgegeven warehouse-id
-    def test_05_put_client_id(self):
+    def test_04_put_client_id(self):
         for version in ["http://localhost:5001/api/v1",
                         "http://localhost:5002/api/v2"]:
             with self.subTest(version=version):
@@ -214,7 +214,7 @@ class TestClass(unittest.TestCase):
                     )
 
     # deze delete een warehouse op basis van een id
-    def test_06_delete_client_id(self):
+    def test_05_delete_client_id(self):
         for version in ["http://localhost:5001/api/v1",
                         "http://localhost:5002/api/v2"]:
             with self.subTest(version=version):


### PR DESCRIPTION
This pull request includes several changes to the `PythonTests/test_Clients.py` file to improve the handling of client IDs in the test cases. The most important changes involve updating the tests to dynamically fetch the last client ID instead of using hardcoded values.

Improvements to test cases:

* [`test_04_post_client`](diffhunk://#diff-ee4b8cbbbb44afa29488db569813c9a2f633db384aa3cfcdcebc75840216a9a6R42-R72): Moved the test_post_client to the start of the test to ensure that a client is in the database
* [`test_02_get_client_id`](diffhunk://#diff-ee4b8cbbbb44afa29488db569813c9a2f633db384aa3cfcdcebc75840216a9a6R107-R120): Modified the test to dynamically fetch the last client ID so that if would grab the client made in the previous post test.
* [`test_06_delete_client_id`](diffhunk://#diff-ee4b8cbbbb44afa29488db569813c9a2f633db384aa3cfcdcebc75840216a9a6R223-R236): Modified the test to dynamically fetch the last client ID before making a request to delete a specific client so that the tests would not effect the database when run.
