### PR TITLE
378 swagger docu

### DIFF
--- a/PythonTests/test_Inventories.py
+++ b/PythonTests/test_Inventories.py
@@ -9,21 +9,7 @@ class TestClass(unittest.TestCase):
                          "http://localhost:5002/api/v2"]
         self.headers = {'Api-Key': 'AdminKey'}
 
-    def test_get_inventories(self):
-        for version in self.versions:
-            with self.subTest(version=version):
-                response = self.client.get(url=(version + "/inventories"),
-                                           headers=self.headers)
-                self.assertEqual(response.status_code, 200)
-
-    def test_get_inventory_id(self):
-        for version in self.versions:
-            with self.subTest(version=version):
-                response = self.client.get(url=(version + "/inventories/1"),
-                                           headers=self.headers)
-                self.assertEqual(response.status_code, 200)
-
-    def test_post_inventory(self):
+    def test_01_post_inventory(self):
         data = {
             "id": 99999,
             "item_id": "ITEM123",
@@ -43,6 +29,22 @@ class TestClass(unittest.TestCase):
                 response = self.client.post(url=(version + "/inventories"),
                                             headers=self.headers, json=data)
                 self.assertEqual(response.status_code, 201)
+
+    def test_get_inventories(self):
+        for version in self.versions:
+            with self.subTest(version=version):
+                response = self.client.get(url=(version + "/inventories"),
+                                           headers=self.headers)
+                self.assertEqual(response.status_code, 200)
+
+    def test_get_inventory_id(self):
+        for version in self.versions:
+            with self.subTest(version=version):
+                response = self.client.get(url=(version + "/inventories/1"),
+                                           headers=self.headers)
+                self.assertEqual(response.status_code, 200)
+
+    
 
     def test_put_inventory_id(self):
         data = {

--- a/V1/Cargohub/Program.cs
+++ b/V1/Cargohub/Program.cs
@@ -7,6 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 builder.Services.AddControllers();
 
 builder.Services.AddTransient<IItemService,ItemService>();
@@ -23,6 +24,10 @@ builder.Services.AddTransient<ITransferService, TransferService>();
 builder.Services.AddTransient<IOrderService, OrderService>();
 
 var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
 app.Urls.Add("http://localhost:5001");
 app.MapControllers();
 

--- a/V1/Cargohub/Werehouses.csproj
+++ b/V1/Cargohub/Werehouses.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="Newtonsoft.json" Version="13.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
 
 </Project>

--- a/V2/Cargohub/Authentication/ApiKeyMiddleware.cs
+++ b/V2/Cargohub/Authentication/ApiKeyMiddleware.cs
@@ -13,6 +13,12 @@ public class ApiKeyMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
+        if (context.Request.Path.StartsWithSegments("/swagger"))
+        {
+            await _next(context);
+            return;
+        }
+        
         if (!context.Request.Headers.TryGetValue(AuthConstants.ApiKeyHeaderName, out
                 var extractedApiKey))
         {

--- a/V2/Cargohub/Program.cs
+++ b/V2/Cargohub/Program.cs
@@ -12,7 +12,7 @@ builder.Services.AddSwaggerGen(options =>
 {
     options.SwaggerDoc("v2", new OpenApiInfo
     {
-        Title = "My API V2",
+        Title = "Warehouse V2",
         Version = "v2",
         Description = "API documentation for version 2"
     });

--- a/V2/Cargohub/Program.cs
+++ b/V2/Cargohub/Program.cs
@@ -1,5 +1,6 @@
 using ServicesV2;
 using ApiKeyAuthentication.Authentication;
+using Microsoft.OpenApi.Models;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -7,6 +8,15 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v2", new OpenApiInfo
+    {
+        Title = "My API V2",
+        Version = "v2",
+        Description = "API documentation for version 2"
+    });
+});
 builder.Services.AddControllers();
 
 builder.Services.AddTransient<IItemService,ItemService>();
@@ -24,6 +34,12 @@ builder.Services.AddTransient<IOrderService, OrderService>();
 builder.Services.AddTransient<IAdminService, AdminService>();
 
 var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI(options =>
+{
+    options.SwaggerEndpoint("/swagger/v2/swagger.json", "My API V2");
+});
 
 app.UseMiddleware<ApiKeyMiddleware>();
 

--- a/V2/Cargohub/Werehouses.csproj
+++ b/V2/Cargohub/Werehouses.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="Newtonsoft.json" Version="13.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
 
 </Project>

--- a/V2/Cargohub/controllers/AdminController.cs
+++ b/V2/Cargohub/controllers/AdminController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 namespace ControllersV2;
 
+[ApiExplorerSettings(IgnoreApi = true)]
 [ApiController]
 [Route("api/v2/admin")]
 public class AdminController : ControllerBase


### PR DESCRIPTION
This pull request includes several changes to the `PythonTests/test_Inventories.py` file and various files in the `Cargohub` project to enhance functionality and improve code organization. The most important changes include reordering test methods, adding Swagger documentation support, and updating package references.

Reordering and updating test methods:

* [`PythonTests/test_Inventories.py`](diffhunk://#diff-14e69392283d2a169dedca7a9a729797c3bc679703023831ec79b460d67574a8L12-R12): Reordered the test methods to follow a numerical naming convention and moved `test_get_inventories` and `test_get_inventory_id` to a different location within the file. [[1]](diffhunk://#diff-14e69392283d2a169dedca7a9a729797c3bc679703023831ec79b460d67574a8L12-R12) [[2]](diffhunk://#diff-14e69392283d2a169dedca7a9a729797c3bc679703023831ec79b460d67574a8R33-R48)

Adding Swagger documentation support:

* [`V1/Cargohub/Program.cs`](diffhunk://#diff-0df0217725b995f45059e763f0526982303738ebae05f6fd4b280ea65931bb03R10): Added Swagger generation and UI services to the application to enable API documentation. [[1]](diffhunk://#diff-0df0217725b995f45059e763f0526982303738ebae05f6fd4b280ea65931bb03R10) [[2]](diffhunk://#diff-0df0217725b995f45059e763f0526982303738ebae05f6fd4b280ea65931bb03R27-R30)
* [`V2/Cargohub/Program.cs`](diffhunk://#diff-d36208917446f73e3681ea400aff55ee85071120e52d5a4a945a253fa5e623bbR3-R19): Included Swagger generation and UI services with specific configuration for version 2 of the API. [[1]](diffhunk://#diff-d36208917446f73e3681ea400aff55ee85071120e52d5a4a945a253fa5e623bbR3-R19) [[2]](diffhunk://#diff-d36208917446f73e3681ea400aff55ee85071120e52d5a4a945a253fa5e623bbR38-R43)

Updating package references:

* `V1/Cargohub/Werehouses.csproj` and `V2/Cargohub/Werehouses.csproj`: Updated `Swashbuckle.AspNetCore` package from version 6.4.0 to 7.2.0.

Other changes:

* [`V2/Cargohub/Authentication/ApiKeyMiddleware.cs`](diffhunk://#diff-eec58533aeb4a795a9af4d945bb0d9eee083a64feb9d65ca6f85067ec58d29b6R16-R21): Added a condition to bypass API key validation for Swagger endpoints.
* [`V2/Cargohub/controllers/AdminController.cs`](diffhunk://#diff-5cec75d5797bd939833e7dc967bd5df729480d78a12f2dad24b7bf5a808c03d2R7): Marked the `AdminController` class to be ignored by API Explorer.