### PR TITLE
383 seperate the maintenance into its own yaml file from main yaml file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,15 +7,8 @@ on:
   pull_request:
     branches:
       - '**'
-  schedule:
-    - cron: '0 3 * * *' # Run every day at 3:00 UTC
 
 jobs:
-  nightly-maintenance:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove old atrifacts
-        run: rm -rf ./artifacts
   csharp-build-and-test:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,5 +1,8 @@
 name: Daily Maintenance
 on:
+    push:
+        branches:
+            '**'
     schedule:
         - cron: '0 3 * * *' #runs every day at 3:00\
 jobs:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,8 +1,5 @@
 name: Daily Maintenance
 on:
-    push:
-        branches:
-            '**'
     schedule:
         - cron: '0 3 * * *' #runs every day at 3:00\
 jobs:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,10 @@
+name: Daily Maintenance
+on:
+    schedule:
+        - cron: '0 3 * * *' #runs every day at 3:00\
+jobs:
+    nightly-maintenance:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Remove old artifacts
+              run: rm -rf ./artifacts


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows, specifically moving the nightly maintenance job to a new workflow file.

Changes to GitHub Actions workflows:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L10-L18): Removed the `schedule` trigger and the `nightly-maintenance` job.
* [`.github/workflows/maintenance.yml`](diffhunk://#diff-6eb5da11d7badb128a54d987e293ca9eec3cbb461d01a0abeae2d7a09675aefbR1-R10): Added a new workflow file for daily maintenance with a `schedule` trigger and the `nightly-maintenance` job.