### PR TITLE
377 test inventoriespy sorted the test in the right order

### DIFF
--- a/PythonTests/test_Clients.py
+++ b/PythonTests/test_Clients.py
@@ -38,7 +38,7 @@ class TestClass(unittest.TestCase):
     def setUp(self):
         self.client = httpx.Client()
         self.headers = httpx.Headers({'Api-Key': 'AdminKey'})
-    
+
     # deze voegt een nieuwe warehouse object
     def test_01_post_client(self):
         for version in ["http://localhost:5001/api/v1",
@@ -117,7 +117,7 @@ class TestClass(unittest.TestCase):
                 # Stuur de request
                 response = self.client.get(
                     url=(self.url + f"/clients/{last_client_id}"),
-                    headers=self.headers)           
+                    headers=self.headers)       
 
                 # Check de status code
                 # Check dat de response een

--- a/PythonTests/test_Inventories.py
+++ b/PythonTests/test_Inventories.py
@@ -10,7 +10,6 @@ class TestClass(unittest.TestCase):
         self.headers = {'Api-Key': 'AdminKey'}
 
     def test_01_post_inventory(self):
-    def test_01_post_inventory(self):
         data = {
             "item_id": "ITEM123",
             "description": "Test description",

--- a/PythonTests/test_Inventories.py
+++ b/PythonTests/test_Inventories.py
@@ -9,23 +9,8 @@ class TestClass(unittest.TestCase):
                          "http://localhost:5002/api/v2"]
         self.headers = {'Api-Key': 'AdminKey'}
 
-    def test_get_inventories(self):
-        for version in self.versions:
-            with self.subTest(version=version):
-                response = self.client.get(url=(version + "/inventories"),
-                                           headers=self.headers)
-                self.assertEqual(response.status_code, 200)
-
-    def test_get_inventory_id(self):
-        for version in self.versions:
-            with self.subTest(version=version):
-                response = self.client.get(url=(version + "/inventories/1"),
-                                           headers=self.headers)
-                self.assertEqual(response.status_code, 200)
-
-    def test_post_inventory(self):
+    def test_01_post_inventory(self):
         data = {
-            "id": 99999,
             "item_id": "ITEM123",
             "description": "Test description",
             "item_reference": "Test reference",
@@ -44,7 +29,31 @@ class TestClass(unittest.TestCase):
                                             headers=self.headers, json=data)
                 self.assertEqual(response.status_code, 201)
 
-    def test_put_inventory_id(self):
+    def test_02_get_inventories(self):
+        for version in self.versions:
+            with self.subTest(version=version):
+                response = self.client.get(url=(version + "/inventories"),
+                                           headers=self.headers)
+                self.assertEqual(response.status_code, 200)
+
+    def test_03_get_inventory_id(self):
+        for version in self.versions:
+            with self.subTest(version=version):
+                response = self.client.get(
+                    url=(version + "/inventories"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get inventories: {response.content}"
+                )
+                inventories = response.json()
+                last_inventory_id = inventories[-1]["id"] if inventories else 1
+
+                response = self.client.get(url=(
+                    version + f"/inventories/{last_inventory_id}"),
+                                           headers=self.headers)
+                self.assertEqual(response.status_code, 200)
+
+    def test_04_put_inventory_id(self):
         data = {
             "id": 1,
             "item_id": "ITEM123",
@@ -61,13 +70,33 @@ class TestClass(unittest.TestCase):
         }
         for version in self.versions:
             with self.subTest(version=version):
-                response = self.client.put(url=(version + "/inventories/1"),
+                response = self.client.get(
+                    url=(version + "/inventories"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get inventories: {response.content}"
+                )
+                inventories = response.json()
+                last_inventory_id = inventories[-1]["id"] if inventories else 1    
+
+                response = self.client.put(url=(
+                    version + f"/inventories/{last_inventory_id}"),
                                            headers=self.headers, json=data)
                 self.assertEqual(response.status_code, 200)
 
-    def test_delete_inventory_id(self):
+    def test_05_delete_inventory_id(self):
         for version in self.versions:
             with self.subTest(version=version):
-                response = self.client.delete(url=(version + "/inventories/5"),
+                response = self.client.get(
+                    url=(version + "/inventories"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get inventories: {response.content}"
+                )
+                inventories = response.json()
+                last_inventory_id = inventories[-1]["id"] if inventories else 1
+
+                response = self.client.delete(url=(
+                    version + f"/inventories/{last_inventory_id}"),
                                               headers=self.headers)
                 self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This pull request includes several changes to the `PythonTests/test_Inventories.py` file to improve the test suite for inventory operations. The changes primarily focus on renaming test methods for better organization and ensuring tests dynamically use the last inventory ID.

Improvements to test method organization:

* Renamed test methods to follow a sequential naming convention, improving readability and organization. (`test_01_post_inventory`, `test_02_get_inventories`, `test_03_get_inventory_id`, `test_04_put_inventory_id`, `test_05_delete_inventory_id`) [[1]](diffhunk://#diff-14e69392283d2a169dedca7a9a729797c3bc679703023831ec79b460d67574a8L33-R56) [[2]](diffhunk://#diff-14e69392283d2a169dedca7a9a729797c3bc679703023831ec79b460d67574a8L66-R100)

Enhancements to inventory ID handling:

* Modified tests to dynamically fetch and use the last inventory ID instead of hardcoding IDs, ensuring tests are more robust and less prone to failure due to fixed IDs. [[1]](diffhunk://#diff-14e69392283d2a169dedca7a9a729797c3bc679703023831ec79b460d67574a8L33-R56) [[2]](diffhunk://#diff-14e69392283d2a169dedca7a9a729797c3bc679703023831ec79b460d67574a8L66-R100)

Other changes:

* Removed the `id` field from the `data` dictionary in the `test_01_post_inventory` method to prevent potential conflicts with auto-generated IDs.