### PR TITLE
fixed the test_items.py order 

### DIFF
--- a/PythonTests/test_Items.py
+++ b/PythonTests/test_Items.py
@@ -9,36 +9,9 @@ class TestClass(unittest.TestCase):
                          "http://localhost:5002/api/v2"]
         self.headers = httpx.Headers({'Api-Key': 'AdminKey'})
 
-    def test_02_get_item_id(self):
-        for url in self.versions:
-            with self.subTest(url=url):
-                response = self.client.get(
-                    url=(url + "/items/P000006"), headers=self.headers
-                )
-                self.assertEqual(response.status_code, 200)
-                self.assertEqual(type(response.json()), dict)
-
-    def test_03_get_items(self):
-        for url in ["http://localhost:5001/api/v1"]:
-            with self.subTest(url=url):
-                response = self.client.get(
-                    url=(url + "/items"), headers=self.headers
-                )
-                self.assertEqual(response.status_code, 200)
-                self.assertEqual(type(response.json()), list)
-
-    def test_03_get_items_v2(self):
-        for url in ["http://localhost:5002/api/v2"]:
-            with self.subTest(url=url):
-                response = self.client.get(
-                    url=(url + "/items"), headers=self.headers
-                )
-                self.assertEqual(response.status_code, 200)
-                self.assertEqual(type(response.json()), dict)
-
-    def test_04_post_item(self):
+    def test_01_post_item(self):
         data = {
-            "uid": "P000001",
+            "uid": "",
             "item_line": 3,
             "item_group": 3,
             "item_type": 3,
@@ -61,7 +34,68 @@ class TestClass(unittest.TestCase):
                     msg=f"Failed to create item: {response.content}"
                 )
 
-    def test_05_put_item_id(self):
+    def test_02_get_items(self):
+        for url in ["http://localhost:5001/api/v1"]:
+            with self.subTest(url=url):
+                response = self.client.get(
+                    url=(url + "/items"), headers=self.headers
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(type(response.json()), list)
+
+    def test_03_get_items_v2(self):
+        for url in ["http://localhost:5002/api/v2"]:
+            with self.subTest(url=url):
+                response = self.client.get(
+                    url=(url + "/items"), headers=self.headers
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(type(response.json()), dict)
+
+    def test_04_get_item_id_v1(self):
+        for url in ["http://localhost:5001/api/v1"]:
+            with self.subTest(url=url):
+                response = self.client.get(
+                    url=(url + "/items"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get items: {response.content}"
+                )
+                items = response.json()
+                last_item_id = items[-1]["uid"] if items else 1
+
+                response = self.client.get(
+                    url=(url + f"/items/{last_item_id}"),
+                    headers=self.headers
+                )
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(type(response.json()), dict)
+
+    def test_04_get_item_id_v2(self):
+        for url in ["http://localhost:5002/api/v2"]:
+            with self.subTest(url=url):
+                response = self.client.get(
+                    url=(url + "/items?page=0"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get items: {response.content}"
+                )
+                items = response.json()
+                last_item_id = (
+                    next(reversed(items.values()))[-1]["uid"] if items else 1
+                )
+                print(last_item_id)
+
+                response = self.client.get(
+                    url=(url + f"/items/{last_item_id}"),
+                    headers=self.headers
+                )
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(type(response.json()), dict)
+
+    def test_05_put_item_id_v1(self):
         data = {
             "uid": "P000003",
             "item_line": 1,
@@ -76,21 +110,93 @@ class TestClass(unittest.TestCase):
             "commodity_code": "COMM003",
             "short_description": "Updated short description"
         }
-        for url in self.versions:
+        for url in ["http://localhost:5001/api/v1"]:
             with self.subTest(url=url):
+                response = self.client.get(
+                    url=(url + "/items"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get items: {response.content}"
+                )
+                items = response.json()
+                last_item_id = items[-1]["uid"] if items else 1
+
                 response = self.client.put(
-                    url=(url + "/items/P000003"),
+                    url=(url + f"/items/{last_item_id}"),
                     headers=self.headers, json=data
                 )
+
                 self.assertEqual(response.status_code, 200)
 
-    def test_06_delete_item_id(self):
-        for url in self.versions:
+    def test_05_put_item_id_v2(self):
+        data = {
+            "uid": "P000003",
+            "item_line": 1,
+            "item_group": 1,
+            "item_type": 1,
+            "supplier_id": 1,
+            "name": "Updated Test Item",
+            "description": "This is an updated test item",
+            "code": "ITEM003",
+            "upc_code": "123456789013",
+            "model_number": "MODEL003",
+            "commodity_code": "COMM003",
+            "short_description": "Updated short description"
+        }
+        for url in ["http://localhost:5002/api/v2"]:
             with self.subTest(url=url):
+                response = self.client.get(
+                    url=(url + "/items?page=0"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get items: {response.content}"
+                )
+                items = response.json()
+                last_item_id = (
+                    next(reversed(items.values()))[-1]["uid"] if items else 1
+                )
+                response = self.client.put(
+                    url=(url + f"/items/{last_item_id}"),
+                    headers=self.headers, json=data
+                )
+
+                self.assertEqual(response.status_code, 200)
+
+    def test_06_delete_item_id_v1(self):
+        for url in ["http://localhost:5001/api/v1"]:
+            with self.subTest(url=url):
+                response = self.client.get(
+                    url=(url + "/items"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get items: {response.content}"
+                )
+                items = response.json()
+                last_item_id = items[-1]["uid"] if items else 1
+
                 response = self.client.delete(
-                    url=(url + "/items/P000001"), headers=self.headers
+                    url=(url + f"/items/{last_item_id}"),
+                    headers=self.headers
                 )
                 self.assertEqual(response.status_code, 200)
 
+    def test_06_delete_item_id_v2(self):
+        for url in ["http://localhost:5002/api/v2"]:
+            with self.subTest(url=url):
+                response = self.client.get(
+                    url=(url + "/items?page=0"), headers=self.headers)
+                self.assertEqual(
+                    response.status_code, 200,
+                    msg=f"Failed to get items: {response.content}"
+                )
+                items = response.json()
+                last_item_id = (
+                    next(reversed(items.values()))[-1]["uid"] if items else 1
+                )
+                response = self.client.delete(
+                    url=(url + f"/items/{last_item_id}"),
+                    headers=self.headers
+                )
+                self.assertEqual(response.status_code, 200)
 
 # to run the file: python -m unittest test_items.py

--- a/V2/Cargohub/controllers/ItemController.cs
+++ b/V2/Cargohub/controllers/ItemController.cs
@@ -113,8 +113,8 @@ public class ItemController : ControllerBase
     */
     [HttpGet()]
     public ActionResult<PaginationCS<ItemCS>> GetAllItems(
-        [FromQuery] itemFilter tofilter, 
-        [FromQuery] int page = 1, 
+        [FromQuery] itemFilter tofilter,
+        [FromQuery] int page = 1,
         [FromQuery] int pageSize = 10)
     {
         List<string> listOfAllowedRoles = new List<string>()
@@ -125,10 +125,12 @@ public class ItemController : ControllerBase
         {
             return Unauthorized();
         }
+
         if (tofilter == null)
         {
             tofilter = new itemFilter();
         }
+
         var items = _itemService.GetAllItems();
         var query = items.AsQueryable();
 
@@ -165,11 +167,19 @@ public class ItemController : ControllerBase
         // Get the filtered count
         int filteredItemsCount = query.Count();
 
-        // Pagination logic
+        // Calculate the total number of pages
         int totalPages = (int)Math.Ceiling(filteredItemsCount / (double)pageSize);
+
+        if (page == 0)
+        {
+            page = totalPages;
+        }
+        page = Math.Max(1, Math.Min(page, totalPages));
+
+        // Fetch the items for the requested page
         var pagedItems = query.Skip((page - 1) * pageSize).Take(pageSize).ToList();
 
-        // Return paginated and filtered result
+        // Return the paginated and filtered result
         var result = new PaginationCS<ItemCS>()
         {
             Page = page,
@@ -180,6 +190,7 @@ public class ItemController : ControllerBase
 
         return Ok(result);
     }
+
     // GET: items
     // Retrieves all items
     /*[HttpGet()]
@@ -217,11 +228,11 @@ public class ItemController : ControllerBase
         {
             return BadRequest("No items to generate report for.");
         }
-        
+
         _itemService.GenerateReport(uids);
         return Ok();
     }
-    
+
 
     // GET: items/5
     // Retrieves an item by its unique identifier (uid)


### PR DESCRIPTION
This pull request includes significant updates to the `PythonTests/test_Items.py` file to improve the organization and functionality of the tests, as well as changes to the `GetAllItems` method in the `ItemController.cs` file to enhance pagination logic.

### Updates to `PythonTests/test_Items.py`:

* **Reorganized Test Methods**: Renamed and reordered test methods to follow a more logical sequence, ensuring that item creation (`test_01_post_item`) occurs before retrieval (`test_02_get_items`), and so on. [[1]](diffhunk://#diff-96283a2153913ad9f1fb6480d22f849e5919c53d0697a2fcd4ccb1fec709cc29L12-R37) [[2]](diffhunk://#diff-96283a2153913ad9f1fb6480d22f849e5919c53d0697a2fcd4ccb1fec709cc29L39-R131)
* **Enhanced Test Coverage**: Added new tests for retrieving item details by ID for both API versions (`test_04_get_item_id_v1` and `test_04_get_item_id_v2`), as well as updating (`test_05_put_item_id_v1`, `test_05_put_item_id_v2`) and deleting items (`test_06_delete_item_id_v1`, `test_06_delete_item_id_v2`). [[1]](diffhunk://#diff-96283a2153913ad9f1fb6480d22f849e5919c53d0697a2fcd4ccb1fec709cc29L39-R131) [[2]](diffhunk://#diff-96283a2153913ad9f1fb6480d22f849e5919c53d0697a2fcd4ccb1fec709cc29L79-R200)

### Updates to `V2/Cargohub/controllers/ItemController.cs`:

* **Improved Pagination Logic**: Added logic to calculate the total number of pages and ensure the requested page number is within valid bounds. If the page number is zero, it defaults to the last page.
* **Code Cleanup**: Added spacing for better readability and consistency in the `GetAllItems` method. [[1]](diffhunk://#diff-84a6afb31e0caa6259fcf31d2219c9ae3123ac4490ce4bd2e60cead4eec0cd7dR128-R133) [[2]](diffhunk://#diff-84a6afb31e0caa6259fcf31d2219c9ae3123ac4490ce4bd2e60cead4eec0cd7dR193)