### PR TITLE
Add tests for POST, PUT, and DELETE item types; update file path for …

### DIFF
--- a/PythonTests/test_ItemTypes.py
+++ b/PythonTests/test_ItemTypes.py
@@ -65,11 +65,39 @@ class TestItemTypesAPI(unittest.TestCase):
                         )
                     )
 
-    def test_05_put_item_type_id(self):
+    def test_04_post_item_type(self):
         for version in self.versions:
             with self.subTest(version=version):
                 data = {
-                    "id": 4,
+                    "name": "New Item Type",
+                    "description": "A new item type",
+                    "created_at": "2023-10-01T00:00:00",
+                    "updated_at": "2023-10-01T00:00:00",
+                }
+
+                # Send the request
+                response = self.client.post(
+                    url=(version + "/itemtypes"),
+                    headers=self.headers,
+                    json=data
+                )
+
+                # Check the status code
+                self.assertEqual(response.status_code, 201)
+
+    def test_05_put_item_type_id(self):
+        for version in self.versions:
+            with self.subTest(version=version):
+                # Get the list of item types to find the last one
+                response = self.client.get(
+                    url=(version + "/itemtypes"), headers=self.headers
+                )
+                self.assertEqual(response.status_code, 200)
+                item_types = response.json()
+                last_item_type_id = item_types[-1]['id'] if item_types else 1
+
+                data = {
+                    "id": last_item_type_id,
                     "name": "Updated Item Type",
                     "description": "An updated item type",
                     "created_at": "2023-10-01T00:00:00",
@@ -78,7 +106,7 @@ class TestItemTypesAPI(unittest.TestCase):
 
                 # Send the request
                 response = self.client.put(
-                    url=(version + "/itemtypes/4"),
+                    url=(version + f"/itemtypes/{last_item_type_id}"),
                     headers=self.headers,
                     json=data
                 )
@@ -89,9 +117,18 @@ class TestItemTypesAPI(unittest.TestCase):
     def test_06_delete_item_type_id(self):
         for version in self.versions:
             with self.subTest(version=version):
+                # Get the list of item types to find the last one
+                response = self.client.get(
+                    url=(version + "/itemtypes"), headers=self.headers
+                )
+                self.assertEqual(response.status_code, 200)
+                item_types = response.json()
+                last_item_type_id = item_types[-1]['id'] if item_types else 1
+
                 # Send the request
                 response = self.client.delete(
-                    url=(version + "/itemtypes/3"), headers=self.headers
+                    url=(version + f"/itemtypes/{last_item_type_id}"),
+                    headers=self.headers
                 )
 
                 # Check the status code

--- a/PythonTests/test_ItemTypes.py
+++ b/PythonTests/test_ItemTypes.py
@@ -18,6 +18,26 @@ class TestItemTypesAPI(unittest.TestCase):
         self.versions = ["http://localhost:5001/api/v1",
                          "http://localhost:5002/api/v2"]
 
+    def test_01_post_item_type(self):
+        for version in self.versions:
+            with self.subTest(version=version):
+                data = {
+                    "name": "New Item Type",
+                    "description": "A new item type",
+                    "created_at": "2023-10-01T00:00:00",
+                    "updated_at": "2023-10-01T00:00:00",
+                }
+
+                # Send the request
+                response = self.client.post(
+                    url=(version + "/itemtypes"),
+                    headers=self.headers,
+                    json=data
+                )
+
+                # Check the status code
+                self.assertEqual(response.status_code, 201)
+
     def test_02_get_item_type_id(self):
         for version in self.versions:
             with self.subTest(version=version):
@@ -65,27 +85,7 @@ class TestItemTypesAPI(unittest.TestCase):
                         )
                     )
 
-    def test_04_post_item_type(self):
-        for version in self.versions:
-            with self.subTest(version=version):
-                data = {
-                    "name": "New Item Type",
-                    "description": "A new item type",
-                    "created_at": "2023-10-01T00:00:00",
-                    "updated_at": "2023-10-01T00:00:00",
-                }
-
-                # Send the request
-                response = self.client.post(
-                    url=(version + "/itemtypes"),
-                    headers=self.headers,
-                    json=data
-                )
-
-                # Check the status code
-                self.assertEqual(response.status_code, 201)
-
-    def test_05_put_item_type_id(self):
+    def test_04_put_item_type_id(self):
         for version in self.versions:
             with self.subTest(version=version):
                 # Get the list of item types to find the last one
@@ -114,7 +114,7 @@ class TestItemTypesAPI(unittest.TestCase):
                 # Check the status code
                 self.assertEqual(response.status_code, 200)
 
-    def test_06_delete_item_type_id(self):
+    def test_05_delete_item_type_id(self):
         for version in self.versions:
             with self.subTest(version=version):
                 # Get the list of item types to find the last one

--- a/V1/Cargohub/services/ItemTypeService.cs
+++ b/V1/Cargohub/services/ItemTypeService.cs
@@ -74,7 +74,7 @@ public class ItemTypeService : IItemtypeService
         existingItem.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);
-        await File.WriteAllTextAsync("data/item_lines.json", jsonData);
+        await File.WriteAllTextAsync("data/item_types.json", jsonData);
 
         return existingItem;
     }


### PR DESCRIPTION
This pull request includes several updates to the `PythonTests/test_ItemTypes.py` and `V1/Cargohub/services/ItemTypeService.cs` files, focusing on improving test coverage and correcting file paths. The most important changes include adding a new test for posting item types, dynamically retrieving the last item type ID for updates and deletions, and fixing the file path for saving item types in the C# service.

Improvements to test coverage:

* [`PythonTests/test_ItemTypes.py`](diffhunk://#diff-5c660d9620897a739b7a0d4da0a5294cca525e388f0c823cb2d16d47f05f3c25R68-R100): Added a new test method `test_04_post_item_type` to verify the creation of a new item type via POST request.

Dynamic retrieval of item type ID:

* [`PythonTests/test_ItemTypes.py`](diffhunk://#diff-5c660d9620897a739b7a0d4da0a5294cca525e388f0c823cb2d16d47f05f3c25L81-R109): Modified `test_05_put_item_type_id` to dynamically retrieve the last item type ID for updating instead of using a hardcoded ID.
* [`PythonTests/test_ItemTypes.py`](diffhunk://#diff-5c660d9620897a739b7a0d4da0a5294cca525e388f0c823cb2d16d47f05f3c25R120-R131): Modified `test_06_delete_item_type_id` to dynamically retrieve the last item type ID for deletion instead of using a hardcoded ID.

File path correction:

* [`V1/Cargohub/services/ItemTypeService.cs`](diffhunk://#diff-ab1daa7c73668094a51c6af77dd071f976bca021d9862f292565a4280a4ce38fL77-R77): Changed the file path from `data/item_lines.json` to `data/item_types.json` when saving item types.