### PR TITLE
385 dependency caching for faster builds 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,13 +116,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Run application
-      run: |
-        dotnet build ./V1/Cargohub/Werehouses.csproj --configuration Release
-        dotnet build ./V2/Cargohub/Werehouses.csproj --configuration Release
-        dotnet run --configuration Release --project ./V1/Cargohub/Werehouses.csproj --urls=http://0.0.0.0:5001/ & sleep 5
-        dotnet run --configuration Release --project ./V2/Cargohub/Werehouses.csproj --urls=http://0.0.0.0:5002/ & sleep 5
-
     - name: Cache Python dependencies
       uses: actions/cache@v3
       with:
@@ -135,6 +128,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+
+    - name: Run application
+      run: |
+        dotnet build ./V1/Cargohub/Werehouses.csproj --configuration Release
+        dotnet build ./V2/Cargohub/Werehouses.csproj --configuration Release
+        dotnet run --configuration Release --project ./V1/Cargohub/Werehouses.csproj --urls=http://0.0.0.0:5001/ & sleep 5
+        dotnet run --configuration Release --project ./V2/Cargohub/Werehouses.csproj --urls=http://0.0.0.0:5002/ & sleep 5
 
     - name: Install Python dependencies
       run: pip install -r ./PythonTests/requirements.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Setup .NET
-      if: matrix.language == 'csharp'
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '8.0.x'
-        install-dir: ${{ runner.temp }}/dotnet
-
     - name: Cache .Net depedencies
       if: matrix.language == 'csharp'
       uses: actions/cache@v3
@@ -36,10 +29,16 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-
 
+    - name: Setup .NET
+      if: matrix.language == 'csharp'
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+        install-dir: ${{ runner.temp }}/dotnet
+
     - name: Restore dependencies
       if: matrix.language == 'csharp'
       run: dotnet restore ./${{ matrix.version }}/Cargohub/Werehouses.sln
-
 
     - name: Build solution
       if: matrix.language == 'csharp'
@@ -124,11 +123,6 @@ jobs:
         dotnet run --configuration Release --project ./V1/Cargohub/Werehouses.csproj --urls=http://0.0.0.0:5001/ & sleep 5
         dotnet run --configuration Release --project ./V2/Cargohub/Werehouses.csproj --urls=http://0.0.0.0:5002/ & sleep 5
 
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    
     - name: Cache Python dependencies
       uses: actions/cache@v3
       with:
@@ -136,6 +130,11 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('PythonTests/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
 
     - name: Install Python dependencies
       run: pip install -r ./PythonTests/requirements.txt


### PR DESCRIPTION
This pull request reorganizes the steps in the `.github/workflows/main.yml` file to ensure that dependencies are set up before they are cached. The most important changes include moving the setup steps for .NET and Python to occur before caching their dependencies and adjusting the order of running the application.

Reorganization of setup steps and caching:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R32-L43): Moved the `.NET` setup step to occur before caching .NET dependencies.
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R127-R138): Moved the `Python` setup step to occur before caching Python dependencies.

Adjustment of application run order:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L120-L131): Moved the `Run application` step to occur after setting up .NET and Python, ensuring that the environment is properly configured before running the application.