### PR TITLE
Made the Pytest for creating on V1 and getting on the V2

### DIFF
--- a/PythonTests/test_Clients.py
+++ b/PythonTests/test_Clients.py
@@ -253,7 +253,7 @@ class TestClass(unittest.TestCase):
             msg=f"Failed to create client: {response.content}"
         )
 
-        url2 = "http://localhost:5001/api/v1"
+        url2 = "http://localhost:5002/api/v2"
         response = self.client.get(
             url=(url2 + "/clients"), headers=self.headers)
         self.assertEqual(

--- a/PythonTests/test_Clients.py
+++ b/PythonTests/test_Clients.py
@@ -228,3 +228,59 @@ class TestClass(unittest.TestCase):
 
                 # Check de status code
                 self.assertEqual(response.status_code, 200)
+
+    def test_06_createV1_getV2_test(self):
+        url1 = "http://localhost:5001/api/v1"
+
+        data = {
+            "name": "Test Client",
+            "address": "123 Test Street",
+            "zip_code": "12345",
+            "city": "Test City",
+            "province": "Test Province",
+            "country": "Test Country",
+            "contact_phone": "123-456-7890",
+            "contact_email": "test@example.com",
+            "created_at": "2023-01-01T00:00:00Z",
+            "updated_at": "2023-01-01T00:00:00Z"
+        }
+        response = self.client.post(
+            url=(url1 + "/clients"),
+            headers=self.headers, json=data)
+
+        self.assertEqual(
+            response.status_code, 201,
+            msg=f"Failed to create client: {response.content}"
+        )
+
+        url2 = "http://localhost:5001/api/v1"
+        response = self.client.get(
+            url=(url2 + "/clients"), headers=self.headers)
+        self.assertEqual(
+            response.status_code, 200,
+            msg=f"Failed to get clients: {response.content}"
+        )
+        clients = response.json()
+        last_client_id = clients[-1]["id"] if clients else 1
+
+        response = self.client.get(
+            url=(url2 + f"/clients/{last_client_id}"),
+            headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+
+        response_data = response.json()
+        self.assertEqual(response_data["name"], data["name"])
+        self.assertEqual(response_data["address"], data["address"])
+        self.assertEqual(response_data["zip_code"], data["zip_code"])
+        self.assertEqual(response_data["city"], data["city"])
+        self.assertEqual(response_data["province"], data["province"])
+        self.assertEqual(response_data["country"], data["country"])
+        self.assertEqual(response_data["contact_phone"], data["contact_phone"])
+        self.assertEqual(response_data["contact_email"], data["contact_email"])
+
+        response = self.client.delete(
+            url=(url2 + f"/clients/{last_client_id}"),
+            headers=self.headers)
+
+        # Check de status code
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This pull request adds a new test case to the `PythonTests/test_Clients.py` file. The new test case, `test_06_createV1_getV2_test`, verifies the creation, retrieval, and deletion of a client in different versions of the API.

The most important change is:

* [`PythonTests/test_Clients.py`](diffhunk://#diff-ee4b8cbbbb44afa29488db569813c9a2f633db384aa3cfcdcebc75840216a9a6R231-R286): Added the `test_06_createV1_getV2_test` method to test the full lifecycle of a client, including creation, retrieval, and deletion between different versions.