### PR TITLE
rewrote the warehouse patch to use FromQuery

### DIFF
--- a/V2/Cargohub/controllers/WarehouseController.cs
+++ b/V2/Cargohub/controllers/WarehouseController.cs
@@ -212,8 +212,8 @@ public class WarehouseController : ControllerBase
     }
     //PATCH: Warehouse/{id}/{property_to_change}
     //''   :     ''   /  ''/      contact == werkt niet
-    [HttpPatch("{id}/{property}")]
-    public ActionResult<WarehouseCS> PatchWarehouse([FromRoute] int id, [FromRoute] string property, [FromBody] object newvalue){
+    [HttpPatch("{id}")]
+    public ActionResult<WarehouseCS> PatchWarehouse([FromRoute] int id, [FromQuery] string property, [FromBody] object newvalue){
         if(newvalue is null){
             return NotFound("Erhm what?");
         }


### PR DESCRIPTION
This pull request includes a change to the `PatchWarehouse` method in the `WarehouseController` to modify the way the `property` parameter is passed. The most important change is:

* [`V2/Cargohub/controllers/WarehouseController.cs`](diffhunk://#diff-70ec61fbf0bac5d4101ed52879eb083dee641e8b7efd8bd175dd973951bcc78bL215-R216): Changed the `PatchWarehouse` method to accept the `property` parameter from the query string instead of the route.