### PR TITLE
ItemLines pytest create in v1 get & delete in v2 #419

### DIFF
--- a/PythonTests/test_ItemLines.py
+++ b/PythonTests/test_ItemLines.py
@@ -143,7 +143,6 @@ class TestItemLines(unittest.TestCase):
         data = {
             "name": "Tech Gadgets",
             "description": "cooler gadgets",
-            "created_at": "2022-08-18T07:05:25"
         }
         response = self.client.post(
             url="http://localhost:5001/api/v1/itemlines",
@@ -170,7 +169,6 @@ class TestItemLines(unittest.TestCase):
 
         self.assertEqual(response.json()['name'], data['name'])
         self.assertEqual(response.json()['description'], data['description'])
-        self.assertEqual(response.json()['created_at'], data['created_at'])
 
         # Delete in v2
         response = self.client.delete(

--- a/PythonTests/test_ItemLines.py
+++ b/PythonTests/test_ItemLines.py
@@ -138,5 +138,50 @@ class TestItemLines(unittest.TestCase):
                 # Check the status code
                 self.assertEqual(response.status_code, 200)
 
+    def test_06_create_in_v1_get_and_delete_in_v2(self):
+        # Create in v1
+        data = {
+            "name": "Tech Gadgets",
+            "description": "cooler gadgets",
+            "created_at": "2022-08-18T07:05:25"
+        }
+        response = self.client.post(
+            url="http://localhost:5001/api/v1/itemlines",
+            headers=self.headers,
+            json=data
+        )
+        self.assertEqual(response.status_code, 201)
+        created_item_line = response.json()
+        created_item_line_id = created_item_line['id']
+
+        # Get in v2
+        response = self.client.get(
+            url=(
+                (
+                    f"http://localhost:5002/api/v2/itemlines/"
+                    f"{created_item_line_id}"
+                )
+            ),
+            headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(type(response.json()), dict)
+        self.assertTrue(checkItemLine(response.json()))
+
+        self.assertEqual(response.json()['name'], data['name'])
+        self.assertEqual(response.json()['description'], data['description'])
+        self.assertEqual(response.json()['created_at'], data['created_at'])
+
+        # Delete in v2
+        response = self.client.delete(
+            url=(
+                (
+                    f"http://localhost:5002/api/v2/itemlines/"
+                    f"{created_item_line_id}"
+                )
+            ),
+            headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
 
 # to run the file: python -m unittest test_item_lines.py


### PR DESCRIPTION
This pull request adds a new test to the `PythonTests/test_ItemLines.py` file to ensure compatibility between API versions. The new test verifies that an item line created in version 1 of the API can be retrieved and deleted using version 2 of the API.

Key changes include:

* Added `test_06_create_in_v1_get_and_delete_in_v2` method to test creating an item line in API v1, retrieving it in API v2, and deleting it in API v2.