### PR TITLE
ItemGroups pytest create in v1 get & delete in v2 #423

### DIFF
--- a/PythonTests/test_ItemGroups.py
+++ b/PythonTests/test_ItemGroups.py
@@ -145,6 +145,46 @@ class TestItemGroups(unittest.TestCase):
                 # Check the status code
                 self.assertEqual(response.status_code, 200)
 
+    def test_07_create_in_v1_get_and_delete_in_v2(self):
+        # Create in v1
+        data = {
+            "name": "Cross Version Group",
+            "description": "Item group is created in v1 and accessed in v2."
+        }
+        create_response = self.client.post(
+            url="http://localhost:5001/api/v1/itemgroups",
+            headers=self.headers,
+            json=data
+        )
+        self.assertEqual(create_response.status_code, 201)
+        created_item_group = create_response.json()
+        created_item_group_id = created_item_group["id"]
+
+        # Get in v2
+        get_response = self.client.get(
+            url=(
+                f"http://localhost:5002/api/v2/itemgroups/"
+                f"{created_item_group_id}"
+            ),
+            headers=self.headers
+        )
+        self.assertEqual(get_response.status_code, 200)
+        self.assertEqual(type(get_response.json()), dict)
+        self.assertTrue(checkItemGroup(get_response.json()))
+
+        self.assertEqual(get_response.json()["name"], data["name"])
+        self.assertEqual(get_response.json()["description"],
+                         data["description"])
+
+        # Delete in v2
+        delete_response = self.client.delete(
+            url=(
+                f"http://localhost:5002/api/v2/itemgroups/"
+                f"{created_item_group_id}"
+            ),
+            headers=self.headers
+        )
+        self.assertEqual(delete_response.status_code, 200)
 
 # to run the file: python -m unittest test_item_groups.py
 # # git checkout . -f


### PR DESCRIPTION
This pull request introduces a new test case to ensure compatibility between API versions when creating and deleting item groups. The most important change is the addition of the `test_07_create_in_v1_get_and_delete_in_v2` method in the `PythonTests/test_ItemGroups.py` file.

New test case for cross-version compatibility:

* [`PythonTests/test_ItemGroups.py`](diffhunk://#diff-baf1a30319b779048731c2996c6e86c295db7dd4c48bf35a4a39dd715577dea2R148-R187): Added `test_07_create_in_v1_get_and_delete_in_v2` to verify that an item group created using API version 1 can be retrieved and deleted using API version 2. The test includes creating an item group in v1, retrieving it in v2, and then deleting it in v2.