### PR TITLE
Items pytest create in v1 get & delete in v2 #426

### DIFF
--- a/PythonTests/test_Items.py
+++ b/PythonTests/test_Items.py
@@ -198,4 +198,69 @@ class TestClass(unittest.TestCase):
                 )
                 self.assertEqual(response.status_code, 200)
 
+    def test_07_create_in_v1_get_and_delete_in_v2(self):
+        # Create item in v1
+        data = {
+            "uid": "",
+            "item_line": 3,
+            "item_group": 3,
+            "item_type": 3,
+            "supplier_id": 3,
+            "name": "Test Item",
+            "description": "This is a test item",
+            "code": "ITEM001",
+            "upc_code": "123456789012",
+            "model_number": "MODEL001",
+            "commodity_code": "COMM001",
+            "short_description": "Short description"
+        }
+        response = self.client.post(
+            url="http://localhost:5001/api/v1/items",
+            headers=self.headers, json=data
+        )
+        self.assertEqual(response.status_code, 201,
+                         msg=f"Failed to create item: {response.content}")
+
+        # Get item in v2
+        response = self.client.get(
+            url="http://localhost:5002/api/v2/items?page=0",
+            headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200,
+                         msg=f"Failed to get items: {response.content}")
+        items = response.json()
+        last_item_id = (
+            next(reversed(items.values()))[-1]["uid"] if items else 1
+        )
+
+        if items:
+            item = next(reversed(items.values()))[-1]
+            self.assertIn("uid", item)
+            self.assertIn("code", item)
+            self.assertEqual(item["code"], data["code"])
+            self.assertIn("description", item)
+            self.assertEqual(item["description"], data["description"])
+            self.assertIn("code", item)
+            self.assertEqual(item["code"], data["code"])
+            self.assertIn("upc_code", item)
+            self.assertEqual(item["upc_code"], data["upc_code"])
+            self.assertIn("model_number", item)
+            self.assertEqual(item["model_number"], data["model_number"])
+            self.assertIn("commodity_code", item)
+            self.assertEqual(item["commodity_code"], data["commodity_code"])
+            self.assertIn("short_description", item)
+            self.assertEqual(
+                item["short_description"], data["short_description"]
+            )
+        else:
+            self.fail("No items found in v2")
+
+        # Delete item in v2
+        response = self.client.delete(
+            url=f"http://localhost:5002/api/v2/items/{last_item_id}",
+            headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200,
+                         msg=f"Failed to delete item: {response.content}")
+
 # to run the file: python -m unittest test_items.py


### PR DESCRIPTION
This pull request adds a new test case to the `PythonTests/test_Items.py` file. The new test case verifies the creation of an item using the v1 API, retrieves the item using the v2 API, and then deletes the item using the v2 API.

The most important change is:

* Added `test_07_create_in_v1_get_and_delete_in_v2` to test creating an item in v1, retrieving it in v2, and deleting it in v2.