### PR TITLE
428 refactor patch endpoint suppliers v2

### DIFF
--- a/V2/Cargohub/controllers/SupplierController.cs
+++ b/V2/Cargohub/controllers/SupplierController.cs
@@ -147,7 +147,7 @@ public class SupplierController : ControllerBase
     }
   
     [HttpPatch("{id}")]
-    public ActionResult<SupplierCS> PatchSupplier([FromRoute] int id, [FromBody] SupplierCS patch)
+    public ActionResult<SupplierCS> PatchSupplier([FromRoute] int id, [FromQuery] string property, [FromBody] object newvalue)
     {
         List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager", "Sales", "Logistics" };
         var userRole = HttpContext.Items["UserRole"]?.ToString();
@@ -163,7 +163,7 @@ public class SupplierController : ControllerBase
             return NotFound();
         }
 
-        var updatedSupplier = _supplierService.PatchSupplier(id, patch);
+        var updatedSupplier = _supplierService.PatchSupplier(id, property, newvalue);
         if (updatedSupplier is null)
         {
             return BadRequest("Failed to patch supplier.");

--- a/V2/Cargohub/services/ISupplierService.cs
+++ b/V2/Cargohub/services/ISupplierService.cs
@@ -7,8 +7,8 @@ public interface ISupplierService
     SupplierCS CreateSupplier(SupplierCS supplier);
     List<SupplierCS> CreateMultipleSuppliers(List<SupplierCS> suppliers);
     SupplierCS UpdateSupplier(int id, SupplierCS supplier);
+    SupplierCS PatchSupplier(int id, string property, object newvalue);
     void DeleteSupplier(int id);
     void DeleteSuppliers(List<int> ids);
     List<ItemCS> GetItemsBySupplierId(int supplierId);
-    SupplierCS PatchSupplier(int id, SupplierCS updateSupplier);
 }

--- a/V2/Cargohub/services/SupplierService.cs
+++ b/V2/Cargohub/services/SupplierService.cs
@@ -117,28 +117,53 @@ public class SupplierService : ISupplierService
         return items?.Where(item => item.supplier_id == supplierId).ToList() ?? new List<ItemCS>();
     }
 
-    public SupplierCS PatchSupplier(int id, SupplierCS updateSupplier)
+    public SupplierCS PatchSupplier(int id, string property, object newvalue)
     {
         var allSuppliers = GetAllSuppliers();
-        var supplierToUpdate = allSuppliers.Single(supplier => supplier.Id == id);
+        var supplierToUpdate = allSuppliers.Find(_ => _.Id == id);
 
         if (supplierToUpdate is not null)
         {
             var currentDateTime = DateTime.Now;
 
             var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
-
-            supplierToUpdate.Code = updateSupplier.Code ?? supplierToUpdate.Code;
-            supplierToUpdate.Name = updateSupplier.Name ?? supplierToUpdate.Name;
-            supplierToUpdate.Address = updateSupplier.Address ?? supplierToUpdate.Address;
-            supplierToUpdate.address_extra = updateSupplier.address_extra ?? supplierToUpdate.address_extra;
-            supplierToUpdate.City = updateSupplier.City ?? supplierToUpdate.City;
-            supplierToUpdate.zip_code = updateSupplier.zip_code ?? supplierToUpdate.zip_code;
-            supplierToUpdate.Province = updateSupplier.Province ?? supplierToUpdate.Province;
-            supplierToUpdate.Country = updateSupplier.Country ?? supplierToUpdate.Country;
-            supplierToUpdate.contact_name = updateSupplier.contact_name ?? supplierToUpdate.contact_name;
-            supplierToUpdate.PhoneNumber = updateSupplier.PhoneNumber ?? supplierToUpdate.PhoneNumber;
-            supplierToUpdate.Reference = updateSupplier.Reference ?? supplierToUpdate.Reference;
+            switch(property){
+                case "Code":
+                    supplierToUpdate.Code = newvalue.ToString();
+                    break;
+                case "Name":
+                    supplierToUpdate.Name = newvalue.ToString();
+                    break;
+                case "Address":
+                    supplierToUpdate.Address = newvalue.ToString();
+                    break;
+                case "address_extra":
+                    supplierToUpdate.address_extra = newvalue.ToString();
+                    break;
+                case "City":
+                    supplierToUpdate.City = newvalue.ToString();
+                    break;
+                case "zip_code":
+                    supplierToUpdate.zip_code = newvalue.ToString();
+                    break;
+                case "Province":
+                    supplierToUpdate.Province = newvalue.ToString();
+                    break;
+                case "Country":
+                    supplierToUpdate.Country = newvalue.ToString();
+                    break;
+                case "contact_name":
+                    supplierToUpdate.contact_name = newvalue.ToString();
+                    break;
+                case "PhoneNumber":
+                    supplierToUpdate.PhoneNumber = newvalue.ToString();
+                    break;
+                case "Reference":
+                    supplierToUpdate.Reference = newvalue.ToString();
+                    break;
+                default:
+                    break;
+            }
             supplierToUpdate.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
 
             var jsonData = JsonConvert.SerializeObject(allSuppliers, Formatting.Indented);

--- a/V2/tests/SupplierTests.cs
+++ b/V2/tests/SupplierTests.cs
@@ -375,7 +375,7 @@ namespace TestsV2
             };
 
             _mockSupplierService.Setup(service => service.GetSupplierById(1)).Returns(existingSupplier);
-            _mockSupplierService.Setup(service => service.PatchSupplier(1, patchSupplier)).Returns(patchSupplier);
+            _mockSupplierService.Setup(service => service.PatchSupplier(1, "Name", "Supp & liers")).Returns(patchSupplier);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Items["UserRole"] = "Admin";  // Set the UserRole in HttpContext
@@ -387,7 +387,7 @@ namespace TestsV2
             };
 
             // Act
-            var result = _supplierController.PatchSupplier(1, patchSupplier);
+            var result = _supplierController.PatchSupplier(1, "Name", "Supp & liers");
             var okResult = result.Result as OkObjectResult;
             var returnedSupplier = okResult.Value as SupplierCS;
 
@@ -432,7 +432,7 @@ namespace TestsV2
             };
 
             // Act
-            var result = _supplierController.PatchSupplier(1, patchSupplier);
+            var result = _supplierController.PatchSupplier(1, "Name", "Supp & liers");
 
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));

--- a/V2/tests/SupplierTests.cs
+++ b/V2/tests/SupplierTests.cs
@@ -361,12 +361,17 @@ namespace TestsV2
 
             var existingSupplier = new SupplierCS
             {
-                Id = 1,
-                Code = "OLD123",
-                Name = "Old Supplier",
-                Address = "Old Address",
-                City = "Old City",
-                Country = "Old Country"
+                Code = "SUP0373",
+                Name = "dag & nacht",
+                Address = "Wall Street 181",
+                address_extra = "Apt. 6996",
+                City = "Houston",
+                zip_code = "4002 AZ",
+                Province = "Texas",
+                Country = "USA",
+                contact_name = "Fem Keijzer",
+                PhoneNumber = "(078) 0013363",
+                Reference = "LPaJ-SUP0001"
             };
 
             _mockSupplierService.Setup(service => service.GetSupplierById(1)).Returns(existingSupplier);


### PR DESCRIPTION
This pull request introduces changes to the `PatchSupplier` method and related tests in the `V2/Cargohub` project. The primary goal of these changes is to modify the `PatchSupplier` method to accept a property name and a new value, allowing for more flexible updates to supplier records.

### Changes to `PatchSupplier` method:

* [`V2/Cargohub/controllers/SupplierController.cs`](diffhunk://#diff-11d2519a8ba5558d2be0da4e7dedb5be77186354e17987d30accaf3ed268c731L150-R150): Updated the `PatchSupplier` method to accept `property` and `newvalue` parameters instead of a `SupplierCS` object. [[1]](diffhunk://#diff-11d2519a8ba5558d2be0da4e7dedb5be77186354e17987d30accaf3ed268c731L150-R150) [[2]](diffhunk://#diff-11d2519a8ba5558d2be0da4e7dedb5be77186354e17987d30accaf3ed268c731L166-R166)
* [`V2/Cargohub/services/ISupplierService.cs`](diffhunk://#diff-2c8254ed1173f90b62913e522b95616b20c8227652bc86cc62e5a084f094ab8fR10-L13): Modified the `ISupplierService` interface to reflect the changes in the `PatchSupplier` method signature.
* [`V2/Cargohub/services/SupplierService.cs`](diffhunk://#diff-133e2935af7375fbe2079721d1770a296906f335b69d20fec274c1791f5c71bcL120-R166): Implemented the new `PatchSupplier` method to handle updates based on the specified property and new value using a switch statement.

### Changes to tests:

* [`V2/tests/SupplierTests.cs`](diffhunk://#diff-3d93140d6bdf8d2b2b6571ec6542ca906884c46966479b65948ec6089eeea7bfL364-R378): Updated the `PatchSupplierTest_Success` and `PatchSupplierTest_Failed` test methods to use the new `PatchSupplier` method signature. [[1]](diffhunk://#diff-3d93140d6bdf8d2b2b6571ec6542ca906884c46966479b65948ec6089eeea7bfL364-R378) [[2]](diffhunk://#diff-3d93140d6bdf8d2b2b6571ec6542ca906884c46966479b65948ec6089eeea7bfL385-R390) [[3]](diffhunk://#diff-3d93140d6bdf8d2b2b6571ec6542ca906884c46966479b65948ec6089eeea7bfL430-R435)