### PR TITLE
424 fixing the created at for all v1 posts

### DIFF
--- a/PythonTests/test_ItemTypes.py
+++ b/PythonTests/test_ItemTypes.py
@@ -138,9 +138,7 @@ class TestItemTypesAPI(unittest.TestCase):
         # Create in v1
         data = {
             "name": "Cross Version Item Type",
-            "description": "An item type created in v1 and accessed in v2",
-            "created_at": "2023-10-01T00:00:00",
-            "updated_at": "2023-10-01T00:00:00",
+            "description": "An item type created in v1 and accessed in v2"
         }
 
         response = self.client.post(
@@ -163,8 +161,6 @@ class TestItemTypesAPI(unittest.TestCase):
 
         self.assertEqual(response.json()['name'], data['name'])
         self.assertEqual(response.json()['description'], data['description'])
-        self.assertEqual(response.json()['created_at'], data['created_at'])
-        self.assertEqual(response.json()['updated_at'], data['updated_at'])
 
         # Delete in v2
         response = self.client.delete(

--- a/V1/Cargohub/services/ClientService.cs
+++ b/V1/Cargohub/services/ClientService.cs
@@ -31,8 +31,12 @@ public class ClientService : IClientService
     public ClientCS CreateClient(ClientCS newClient)
     {
         List<ClientCS> clients = GetAllClients();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         newClient.Id = clients.Count > 0 ? clients.Max(c => c.Id) + 1 : 1;
+        newClient.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newClient.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         clients.Add(newClient);
 
         var jsonData = JsonConvert.SerializeObject(clients, Formatting.Indented);

--- a/V1/Cargohub/services/InventoryService.cs
+++ b/V1/Cargohub/services/InventoryService.cs
@@ -47,13 +47,14 @@ public class InventoryService : IInventoryService
 
     public InventoryCS CreateInventory(InventoryCS newInventory)
     {
-
         List<InventoryCS> inventories = GetAllInventories();
-
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         newInventory.Id = inventories.Count > 0 ? inventories.Max(i => i.Id) + 1 : 1;
+        newInventory.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newInventory.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         inventories.Add(newInventory);
-
 
         var jsonData = JsonConvert.SerializeObject(inventories, Formatting.Indented);
         File.WriteAllText(Path, jsonData);

--- a/V1/Cargohub/services/ItemGroupService.cs
+++ b/V1/Cargohub/services/ItemGroupService.cs
@@ -44,25 +44,28 @@ public class ItemGroupService : ItemService, IitemGroupService
         return find;
     }
 
-    public async Task<ItemGroupCS> CreateItemGroup(ItemGroupCS newItemType)
+    public async Task<ItemGroupCS> CreateItemGroup(ItemGroupCS newItemGroup)
     {
         List<ItemGroupCS> items = GetAllItemGroups();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         if (items.Any())
         {
-            newItemType.Id = items.Max(i => i.Id) + 1;
+            newItemGroup.Id = items.Max(i => i.Id) + 1;
         }
         else
         {
-            newItemType.Id = 1;
+            newItemGroup.Id = 1;
         }
-
-        items.Add(newItemType);
+        newItemGroup.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newItemGroup.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        items.Add(newItemGroup);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);
         await File.WriteAllTextAsync(Path, jsonData);
 
-        return newItemType;
+        return newItemGroup;
     }
 
     // Method to update an existing Itemgroup

--- a/V1/Cargohub/services/ItemLineServices.cs
+++ b/V1/Cargohub/services/ItemLineServices.cs
@@ -35,6 +35,8 @@ public class ItemLineService : IItemLineService
     public async Task<ItemLineCS> AddItemLine(ItemLineCS newItemLine)
     {
         List<ItemLineCS> items = GetAllItemlines();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         if (items.Any())
         {
@@ -44,7 +46,8 @@ public class ItemLineService : IItemLineService
         {
             newItemLine.Id = 1;
         }
-
+        newItemLine.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newItemLine.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         items.Add(newItemLine);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);

--- a/V1/Cargohub/services/ItemService.cs
+++ b/V1/Cargohub/services/ItemService.cs
@@ -49,6 +49,8 @@ public class ItemService : IItemService
     public ItemCS CreateItem(ItemCS item)
     {
         List<ItemCS> items;
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         if (File.Exists(path))
         {
@@ -65,14 +67,15 @@ public class ItemService : IItemService
         {
             var maxUid = items.Max(i => i.uid);
             var numericPart = int.Parse(maxUid.Substring(1));
-            newUid = "P" + (numericPart + 1).ToString("D6"); 
+            newUid = "P" + (numericPart + 1).ToString("D6");
         }
         else
         {
-            newUid = "P000001"; 
+            newUid = "P000001";
         }
         item.uid = newUid;
-
+        item.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        item.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         items.Add(item);
 
         var updatedJsonData = JsonConvert.SerializeObject(items, Formatting.Indented);

--- a/V1/Cargohub/services/ItemTypeService.cs
+++ b/V1/Cargohub/services/ItemTypeService.cs
@@ -31,6 +31,8 @@ public class ItemTypeService : IItemtypeService
     public async Task<ItemTypeCS> CreateItemType(ItemTypeCS newItemType)
     {
         List<ItemTypeCS> items = GetAllItemtypes();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         if (items.Any())
         {
@@ -40,7 +42,8 @@ public class ItemTypeService : IItemtypeService
         {
             newItemType.Id = 1;
         }
-
+        newItemType.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newItemType.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         items.Add(newItemType);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);

--- a/V1/Cargohub/services/LocationService.cs
+++ b/V1/Cargohub/services/LocationService.cs
@@ -42,8 +42,12 @@ public class LocationService : ILocationService
     public LocationCS CreateLocation(LocationCS newLocation)
     {
         List<LocationCS> locations = GetAllLocations();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         newLocation.Id = locations.Count > 0 ? locations.Max(o => o.Id) + 1 : 1;
+        newLocation.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newLocation.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         locations.Add(newLocation);
 
         var jsonData = JsonConvert.SerializeObject(locations, Formatting.Indented);

--- a/V1/Cargohub/services/OrderService.cs
+++ b/V1/Cargohub/services/OrderService.cs
@@ -32,12 +32,17 @@ public class OrderService : IOrderService
     }
     public OrderCS CreateOrder(OrderCS newOrder)
     {
-
         List<OrderCS> orders = GetAllOrders();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
+        // Add the new order record to the list
         newOrder.Id = orders.Count > 0 ? orders.Max(o => o.Id) + 1 : 1;
+        newOrder.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newOrder.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         orders.Add(newOrder);
 
+        // Serialize the updated list back to the JSON file
         var jsonData = JsonConvert.SerializeObject(orders, Formatting.Indented);
         File.WriteAllText(path, jsonData);
         return newOrder;

--- a/V1/Cargohub/services/ShipmentService.cs
+++ b/V1/Cargohub/services/ShipmentService.cs
@@ -43,14 +43,15 @@ public class ShipmentService : IShipmentService
     }
     public ShipmentCS CreateShipment(ShipmentCS newShipment)
     {
-
         List<ShipmentCS> shipments = GetAllShipments();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
-        // Add the new shipment record to the list
         newShipment.Id = shipments.Count > 0 ? shipments.Max(w => w.Id) + 1 : 1;
+        newShipment.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newShipment.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         shipments.Add(newShipment);
 
-        // Serialize the updated list back to the JSON file
         var jsonData = JsonConvert.SerializeObject(shipments, Formatting.Indented);
         File.WriteAllText(Path, jsonData);
         return newShipment;

--- a/V1/Cargohub/services/SupplierService.cs
+++ b/V1/Cargohub/services/SupplierService.cs
@@ -34,8 +34,13 @@ public class SupplierService : ISupplierService
     public SupplierCS CreateSupplier(SupplierCS newSupplier)
     {
         List<SupplierCS> suppliers = GetAllSuppliers();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         newSupplier.Id = suppliers.Count > 0 ? suppliers.Max(o => o.Id) + 1 : 1;
+
+        newSupplier.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newSupplier.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         suppliers.Add(newSupplier);
 
         var jsonData = JsonConvert.SerializeObject(suppliers, Formatting.Indented);

--- a/V1/Cargohub/services/TransferService.cs
+++ b/V1/Cargohub/services/TransferService.cs
@@ -44,8 +44,12 @@ public class TransferService : ITransferService
     public TransferCS CreateTransfer(TransferCS newTransfer)
     {
         List<TransferCS> transfers = GetAllTransfers();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         newTransfer.Id = transfers.Count > 0 ? transfers.Max(t => t.Id) + 1 : 1;
+        newTransfer.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newTransfer.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         transfers.Add(newTransfer);
 
         var jsonData = JsonConvert.SerializeObject(transfers, Formatting.Indented);

--- a/V1/Cargohub/services/WarehouseService.cs
+++ b/V1/Cargohub/services/WarehouseService.cs
@@ -33,8 +33,12 @@ public class WarehouseService : IWarehouseService
     public WarehouseCS CreateWarehouse(WarehouseCS newWarehouse)
     {
         List<WarehouseCS> warehouses = GetAllWarehouses();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         newWarehouse.Id = warehouses.Count > 0 ? warehouses.Max(w => w.Id) + 1 : 1;
+        newWarehouse.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newWarehouse.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         warehouses.Add(newWarehouse);
 
         var jsonData = JsonConvert.SerializeObject(warehouses, Formatting.Indented);

--- a/V2/Cargohub/services/InventoryService.cs
+++ b/V2/Cargohub/services/InventoryService.cs
@@ -55,7 +55,6 @@ public class InventoryService : IInventoryService
 
     public InventoryCS CreateInventory(InventoryCS newInventory)
     {
-
         List<InventoryCS> inventories = GetAllInventories();
         var currentDateTime = DateTime.Now;
         var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");

--- a/V2/Cargohub/services/ItemService.cs
+++ b/V2/Cargohub/services/ItemService.cs
@@ -36,7 +36,7 @@ public class ItemService : IItemService
 
     public IEnumerable<ItemCS> GetAllItemsInItemType(int itemTypeId)
     {
-        List<ItemCS> itemTypeItems = new List<ItemCS> ();
+        List<ItemCS> itemTypeItems = new List<ItemCS>();
         var items = GetAllItems();
         foreach (ItemCS item in items)
         {
@@ -69,15 +69,17 @@ public class ItemService : IItemService
         if (!Directory.Exists(directory))
         {
             Directory.CreateDirectory(directory);
-        }        
-        File.WriteAllLines(_path, reportStrings); 
+        }
+        File.WriteAllLines(_path, reportStrings);
 
     }
 
 
-       public ItemCS CreateItem(ItemCS item)
+    public ItemCS CreateItem(ItemCS item)
     {
         List<ItemCS> items;
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         if (File.Exists(path))
         {
@@ -93,15 +95,16 @@ public class ItemService : IItemService
         if (items.Count > 0)
         {
             var maxUid = items.Max(i => i.uid);
-            var numericPart = int.Parse(maxUid.Substring(1)); 
+            var numericPart = int.Parse(maxUid.Substring(1));
             newUid = "P" + (numericPart + 1).ToString("D6");
         }
         else
         {
-            newUid = "P000001"; 
+            newUid = "P000001";
         }
         item.uid = newUid;
-
+        item.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        item.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         items.Add(item);
 
         var updatedJsonData = JsonConvert.SerializeObject(items, Formatting.Indented);
@@ -110,10 +113,10 @@ public class ItemService : IItemService
         return item;
     }
 
-    public List<ItemCS> CreateMultipleItems(List<ItemCS>newItems)
+    public List<ItemCS> CreateMultipleItems(List<ItemCS> newItems)
     {
         List<ItemCS> addedItem = new List<ItemCS>();
-        foreach(ItemCS item in newItems)
+        foreach (ItemCS item in newItems)
         {
             ItemCS addItem = CreateItem(item);
             addedItem.Add(addItem);
@@ -155,59 +158,62 @@ public class ItemService : IItemService
 
         return existingItem;
     }
-    public ItemCS PatchItem(string uid, string property, object newvalue){
+    public ItemCS PatchItem(string uid, string property, object newvalue)
+    {
         var formattednow = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
         var items = GetAllItems();
-        var item = items.Find(_=>_.uid == uid);
-        if(item is null){
+        var item = items.Find(_ => _.uid == uid);
+        if (item is null)
+        {
             return null;
         }
-        switch(property){
-            case"code":
-            item.code = newvalue.ToString();
-            break;
-            case"description":
-            item.description = newvalue.ToString();
-            break;
-            case"short_description":
-            item.short_description = newvalue.ToString();
-            break;
-            case"upc_code":
-            item.upc_code = newvalue.ToString();
-            break;
-            case"model_number":
-            item.model_number = newvalue.ToString();
-            break;
-            case"commodity_code":
-            item.commodity_code = newvalue.ToString();
-            break;
-            case"item_line":
-            item.item_line = (int)newvalue;
-            break;
-            case"item_group":
-            item.item_group = (int) newvalue;
-            break;
-            case"item_type":
-            item.item_type = (int)newvalue;
-            break;
-            case"unit_purchase_quantity":
-            item.unit_purchase_quantity = (int)newvalue;
-            break;
-            case"unit_order_quantity":
-            item.unit_order_quantity = (int)newvalue;
-            break;
-            case"pack_order_quantity":
-            item.pack_order_quantity = (int)newvalue;
-            break;
-            case"supplier_id":
-            item.supplier_id = (int)newvalue;
-            break;
-            case"supplier_code":
-            item.supplier_code = newvalue.ToString();
-            break;
-            case"supplier_part_number":
-            item.supplier_part_number = newvalue.ToString();
-            break;
+        switch (property)
+        {
+            case "code":
+                item.code = newvalue.ToString();
+                break;
+            case "description":
+                item.description = newvalue.ToString();
+                break;
+            case "short_description":
+                item.short_description = newvalue.ToString();
+                break;
+            case "upc_code":
+                item.upc_code = newvalue.ToString();
+                break;
+            case "model_number":
+                item.model_number = newvalue.ToString();
+                break;
+            case "commodity_code":
+                item.commodity_code = newvalue.ToString();
+                break;
+            case "item_line":
+                item.item_line = (int)newvalue;
+                break;
+            case "item_group":
+                item.item_group = (int)newvalue;
+                break;
+            case "item_type":
+                item.item_type = (int)newvalue;
+                break;
+            case "unit_purchase_quantity":
+                item.unit_purchase_quantity = (int)newvalue;
+                break;
+            case "unit_order_quantity":
+                item.unit_order_quantity = (int)newvalue;
+                break;
+            case "pack_order_quantity":
+                item.pack_order_quantity = (int)newvalue;
+                break;
+            case "supplier_id":
+                item.supplier_id = (int)newvalue;
+                break;
+            case "supplier_code":
+                item.supplier_code = newvalue.ToString();
+                break;
+            case "supplier_part_number":
+                item.supplier_part_number = newvalue.ToString();
+                break;
         }
         item.updated_at = DateTime.ParseExact(formattednow, "yyyy-MM-dd HH:mm:ss", null);
         var json = JsonConvert.SerializeObject(items, Formatting.Indented);

--- a/V2/Cargohub/services/OrderService.cs
+++ b/V2/Cargohub/services/OrderService.cs
@@ -44,7 +44,6 @@ public class OrderService : IOrderService
     }
     public OrderCS CreateOrder(OrderCS newOrder)
     {
-
         List<OrderCS> orders = GetAllOrders();
         var currentDateTime = DateTime.Now;
         var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");

--- a/V2/Cargohub/services/ShipmentService.cs
+++ b/V2/Cargohub/services/ShipmentService.cs
@@ -43,10 +43,13 @@ public class ShipmentService : IShipmentService
     }
     public ShipmentCS CreateShipment(ShipmentCS newShipment)
     {
-
         List<ShipmentCS> shipments = GetAllShipments();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         newShipment.Id = shipments.Count > 0 ? shipments.Max(w => w.Id) + 1 : 1;
+        newShipment.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newShipment.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         shipments.Add(newShipment);
 
         var jsonData = JsonConvert.SerializeObject(shipments, Formatting.Indented);

--- a/V2/Cargohub/services/WarehouseService.cs
+++ b/V2/Cargohub/services/WarehouseService.cs
@@ -34,8 +34,12 @@ public class WarehouseService : IWarehouseService
     public WarehouseCS CreateWarehouse(WarehouseCS newWarehouse)
     {
         List<WarehouseCS> warehouses = GetAllWarehouses();
+        var currentDateTime = DateTime.Now;
+        var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         newWarehouse.Id = warehouses.Count > 0 ? warehouses.Max(w => w.Id) + 1 : 1;
+        newWarehouse.created_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
+        newWarehouse.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
         warehouses.Add(newWarehouse);
         
         // Serialize the updated list back to the JSON file


### PR DESCRIPTION
This pull request focuses on adding timestamp fields (`created_at` and `updated_at`) to various entity creation methods across multiple services. The changes ensure that each new record is timestamped with the current date and time when it is created.

Timestamp addition:

* [`V1/Cargohub/services/ClientService.cs`](diffhunk://#diff-389c822bc649956710e847580434af35412f9a1bf7cabbcc76f61a26dce16d1bR34-R39): Added `created_at` and `updated_at` fields with the current timestamp when creating a new client.
* [`V1/Cargohub/services/InventoryService.cs`](diffhunk://#diff-e5ff49a60c2278668f6e9ba8e6616f0eb98b8fb1f2220eb2a8c69eb1d52bc049L50-L57): Added `created_at` and `updated_at` fields with the current timestamp when creating a new inventory.
* [`V1/Cargohub/services/ItemGroupService.cs`](diffhunk://#diff-9b6e4c9d8b177f8c6a6ff471830ab1ee1cd4b76aad154e8327c5505a2c234e17L47-R68): Added `created_at` and `updated_at` fields with the current timestamp when creating a new item group.
* [`V1/Cargohub/services/ItemLineServices.cs`](diffhunk://#diff-ece817e49390e4f75430e8939061b6085516dbae8b192d06360203f3979a1bafR38-R39): Added `created_at` and `updated_at` fields with the current timestamp when creating a new item line. [[1]](diffhunk://#diff-ece817e49390e4f75430e8939061b6085516dbae8b192d06360203f3979a1bafR38-R39) [[2]](diffhunk://#diff-ece817e49390e4f75430e8939061b6085516dbae8b192d06360203f3979a1bafL47-R50)
* [`V1/Cargohub/services/ItemService.cs`](diffhunk://#diff-76e63167adad209bafa1f24e8375bd53a9458d1e10c1195a6d506c1712b8de31R52-R53): Added `created_at` and `updated_at` fields with the current timestamp when creating a new item. [[1]](diffhunk://#diff-76e63167adad209bafa1f24e8375bd53a9458d1e10c1195a6d506c1712b8de31R52-R53) [[2]](diffhunk://#diff-76e63167adad209bafa1f24e8375bd53a9458d1e10c1195a6d506c1712b8de31L75-R78)

These changes ensure that all new records across the different services are consistently timestamped, improving data tracking and consistency.