### PR TITLE
432 refactor patch endpoint in itemline v2

### DIFF
--- a/V2/Cargohub/controllers/ItemLineController.cs
+++ b/V2/Cargohub/controllers/ItemLineController.cs
@@ -189,7 +189,7 @@ public class ItemLineController : ControllerBase
     }
 
     [HttpPatch("{id}")]
-    public ActionResult<ItemLineCS> PatchItemLine([FromRoute] int id, [FromBody] ItemLineCS itemLine)
+    public ActionResult<ItemLineCS> PatchItemLine([FromRoute] int id, [FromQuery] string property, [FromBody] object newvalue)
     {
         List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager", "Inventory Manager" };
         var userRole = HttpContext.Items["UserRole"]?.ToString();
@@ -198,11 +198,9 @@ public class ItemLineController : ControllerBase
         {
             return Unauthorized();
         }
-
-        itemLine.Id = id;
-        if (id != itemLine.Id)
+        if(property == null || newvalue == null)
         {
-            return BadRequest();
+            return BadRequest("Property or new value is null");
         }
 
         var existingItemLine = _itemLineService.GetItemLineById(id);
@@ -211,7 +209,7 @@ public class ItemLineController : ControllerBase
             return NotFound();
         }
 
-        var updatedItemLine = _itemLineService.PatchItemLine(id, itemLine);
+        var updatedItemLine = _itemLineService.PatchItemLine(id, property, newvalue);
         return Ok(updatedItemLine);
     }
 }

--- a/V2/Cargohub/services/IItemLineServices.cs
+++ b/V2/Cargohub/services/IItemLineServices.cs
@@ -13,5 +13,5 @@ public interface IItemLineService
     void DeleteItemLine(int id);
     List<ItemCS> GetItemsByItemLineId(int itemlineId);
     void DeleteItemLines(List<int> ids);
-    ItemLineCS PatchItemLine(int id, ItemLineCS itemLine);
+    ItemLineCS PatchItemLine(int id, string property, object newvalue);
 }

--- a/V2/Cargohub/services/ItemLineServices.cs
+++ b/V2/Cargohub/services/ItemLineServices.cs
@@ -140,10 +140,10 @@ public class ItemLineService : IItemLineService
         File.WriteAllText(_path, json);
     }
 
-    public ItemLineCS PatchItemLine(int id, ItemLineCS itemLine)
+    public ItemLineCS PatchItemLine(int id, string property, object newvalue)
     {
         List<ItemLineCS> items = GetAllItemlines();
-        var existingItem = items.FirstOrDefault(i => i.Id == id);
+        var existingItem = items.Find(i => i.Id == id);
         if (existingItem == null)
         {
             return null;
@@ -154,9 +154,17 @@ public class ItemLineService : IItemLineService
 
         // Format the date and time to the desired format
         var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
-
-        existingItem.Name = itemLine.Name ?? existingItem.Name;
-        existingItem.Description = itemLine.Description ?? existingItem.Description;
+        switch (property)
+        {
+            case "Name":
+                existingItem.Name = newvalue.ToString();
+                break;
+            case "Description":
+                existingItem.Description = newvalue.ToString();
+                break;
+            default:
+                break;
+        }
         existingItem.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);

--- a/V2/tests/ItemLineTests.cs
+++ b/V2/tests/ItemLineTests.cs
@@ -367,7 +367,7 @@ public class ItemLineTests
         var patchItemLine = new ItemLineCS { Description = "Updated Description" };
 
         _mockItemLineService.Setup(service => service.GetItemLineById(1)).Returns(existingItemLine);
-        _mockItemLineService.Setup(service => service.PatchItemLine(1, patchItemLine)).Returns(patchItemLine);
+        _mockItemLineService.Setup(service => service.PatchItemLine(1, "Description", "Updated Description")).Returns(patchItemLine);
 
         var httpContext = new DefaultHttpContext();
         httpContext.Items["UserRole"] = "Admin";  // Set the UserRole in HttpContext
@@ -379,7 +379,7 @@ public class ItemLineTests
         };
 
         // Act
-        var result = _itemLineController.PatchItemLine(1, patchItemLine);
+        var result = _itemLineController.PatchItemLine(1, "Description", "Updated Description");
         var okResult = result.Result as OkObjectResult;
         var returnedItemLine = okResult.Value as ItemLineCS;
 
@@ -408,7 +408,7 @@ public class ItemLineTests
         };
 
         // Act
-        var result = _itemLineController.PatchItemLine(1, patchItemLine);
+        var result = _itemLineController.PatchItemLine(1, "Description", "Updated Description");
 
         // Assert
         Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));


### PR DESCRIPTION
This pull request includes changes to the `PatchItemLine` method in the `ItemLineController`, `ItemLineServices`, and corresponding tests to improve flexibility by allowing updates to specific properties of an `ItemLineCS` object. The most important changes include modifying the method signatures and logic to handle property-specific updates.

Changes to `PatchItemLine` method:

* [`V2/Cargohub/controllers/ItemLineController.cs`](diffhunk://#diff-fbe405a027e617fd45704c6afea615a32a225b73e95a9aa9bb9addfa3e68c79bL192-R192): Updated the `PatchItemLine` method to accept a property name and new value as parameters, and added validation for these parameters. [[1]](diffhunk://#diff-fbe405a027e617fd45704c6afea615a32a225b73e95a9aa9bb9addfa3e68c79bL192-R192) [[2]](diffhunk://#diff-fbe405a027e617fd45704c6afea615a32a225b73e95a9aa9bb9addfa3e68c79bL201-R203) [[3]](diffhunk://#diff-fbe405a027e617fd45704c6afea615a32a225b73e95a9aa9bb9addfa3e68c79bL214-R212)

Updates to service interface and implementation:

* [`V2/Cargohub/services/IItemLineServices.cs`](diffhunk://#diff-e8c136390921b4b3143dcef49e08d65946d35de2e1c8a2a7be39d52899db3bc9L16-R16): Changed the `PatchItemLine` method signature to accept a property name and new value.
* [`V2/Cargohub/services/ItemLineServices.cs`](diffhunk://#diff-290cef8ee8e42154b48f035000ec84868c33380946cd7fb00bae11117b7a5318L143-R146): Modified the `PatchItemLine` method to update the specified property of an `ItemLineCS` object based on the provided property name and new value. [[1]](diffhunk://#diff-290cef8ee8e42154b48f035000ec84868c33380946cd7fb00bae11117b7a5318L143-R146) [[2]](diffhunk://#diff-290cef8ee8e42154b48f035000ec84868c33380946cd7fb00bae11117b7a5318L157-R167)

Adjustments to tests:

* [`V2/tests/ItemLineTests.cs`](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92L370-R370): Updated the tests for the `PatchItemLine` method to reflect the new method signature and ensure proper functionality. [[1]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92L370-R370) [[2]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92L382-R382) [[3]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92L411-R411)