### PR TITLE
437 refactor patch endpoint in itemgroup v2

### DIFF
--- a/V2/Cargohub/controllers/ItemGroupController.cs
+++ b/V2/Cargohub/controllers/ItemGroupController.cs
@@ -141,7 +141,7 @@ public class ItemGroupController : ControllerBase
     }
 
     [HttpPatch("{id}")]
-    public ActionResult<ItemGroupCS> PatchItemGroup([FromRoute] int id, [FromBody] ItemGroupCS itemGroup)
+    public ActionResult<ItemGroupCS> PatchItemGroup([FromRoute] int id, [FromQuery] string property, [FromBody] object newvalue)
     {
         List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager", "Inventory Manager" };
         var userRole = HttpContext.Items["UserRole"]?.ToString();
@@ -150,17 +150,19 @@ public class ItemGroupController : ControllerBase
         {
             return Unauthorized();
         }
-        
+
         var existingItemGroup = _itemgroupService.GetItemById(id);
         if (existingItemGroup == null)
         {
             return NotFound();
         }
 
-        itemGroup.Id = id;
-        var updatedItemGroup = _itemgroupService.PatchItemGroup(id, itemGroup);
-
-        return Ok(updatedItemGroup);
+        if(property == null || newvalue == null)
+        {
+            return BadRequest();
+        }
+        var patched = _itemgroupService.PatchItemGroup(id, property, newvalue);
+        return Ok(patched);
     }
 
     [HttpDelete("{id}")]

--- a/V2/Cargohub/services/IItemGroupService.cs
+++ b/V2/Cargohub/services/IItemGroupService.cs
@@ -13,5 +13,5 @@ public interface IitemGroupService
     List<ItemCS> ItemsFromItemGroupId(int itemgroup_id);
     void DeleteItemGroup(int id);
     void DeleteItemGroups(List<int> ids);
-    ItemGroupCS PatchItemGroup(int Id, ItemGroupCS itemGroup);
+    ItemGroupCS PatchItemGroup(int Id, string property, object newvalue);
 }

--- a/V2/Cargohub/services/ItemGroupService.cs
+++ b/V2/Cargohub/services/ItemGroupService.cs
@@ -126,10 +126,10 @@ public class ItemGroupService : ItemService, IitemGroupService
         File.WriteAllText(Path, jsonData);
     }
 
-    public ItemGroupCS PatchItemGroup(int Id, ItemGroupCS itemGroup)
+    public ItemGroupCS PatchItemGroup(int Id, string property, object newvalue)
     {
         List<ItemGroupCS> items = GetAllItemGroups();
-        var existingItem = items.FirstOrDefault(i => i.Id == Id);
+        var existingItem = items.Find(i => i.Id == Id);
         if (existingItem == null)
         {
             return null;
@@ -140,9 +140,17 @@ public class ItemGroupService : ItemService, IitemGroupService
 
         // Format the date and time to the desired format
         var formattedDateTime = currentDateTime.ToString("yyyy-MM-dd HH:mm:ss");
+        switch(property){
+            case "Name":
+                existingItem.Name = newvalue.ToString();
+                break;
+            case "Description":
+                existingItem.Description = newvalue.ToString();
+                break;
+            default:
+                return null;
+        }
 
-        existingItem.Name = itemGroup.Name ?? existingItem.Name;
-        existingItem.Description = itemGroup.Description ?? existingItem.Description;
         existingItem.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);

--- a/V2/tests/ItemGroupTests.cs
+++ b/V2/tests/ItemGroupTests.cs
@@ -333,11 +333,11 @@ namespace itemgroup.TestsV2
         public void PatchItemGroupTest_Success()
         {
             // Arrange
-            var existingItemGroup = new ItemGroupCS { Id = 1, Name = "Group 1", Description = "Existing Description" };
-            var patchItemGroup = new ItemGroupCS { Name = "Updated Group", Description = "Updated Description" };
+            var existingItemGroup = new ItemGroupCS { Id = 1, Name = "Group 1"  };
+            var patchItemGroup = new ItemGroupCS { Name = "Updated Group" };
 
             _mockItemGroupService.Setup(service => service.GetItemById(1)).Returns(existingItemGroup);
-            _mockItemGroupService.Setup(service => service.PatchItemGroup(1, patchItemGroup)).Returns(patchItemGroup);
+            _mockItemGroupService.Setup(service => service.PatchItemGroup(1, "Name", "Updated Group")).Returns(patchItemGroup);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Items["UserRole"] = "Admin";  // Set the UserRole in HttpContext
@@ -349,7 +349,7 @@ namespace itemgroup.TestsV2
             };
 
             // Act
-            var result = _itemGroupController.PatchItemGroup(1, patchItemGroup);
+            var result = _itemGroupController.PatchItemGroup(1, "Name", "Updated Group");
             var okResult = result.Result as OkObjectResult;
             var returnedItemGroup = okResult.Value as ItemGroupCS;
 
@@ -358,7 +358,6 @@ namespace itemgroup.TestsV2
             Assert.IsNotNull(okResult);
             Assert.IsInstanceOfType(okResult.Value, typeof(ItemGroupCS));
             Assert.AreEqual(patchItemGroup.Name, returnedItemGroup.Name);
-            Assert.AreEqual(patchItemGroup.Description, returnedItemGroup.Description);
         }
 
         [TestMethod]
@@ -379,7 +378,7 @@ namespace itemgroup.TestsV2
             };
 
             // Act
-            var result = _itemGroupController.PatchItemGroup(1, patchItemGroup);
+            var result = _itemGroupController.PatchItemGroup(1, "Name", "Updated Group");
 
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));


### PR DESCRIPTION
This pull request involves significant changes to the `PatchItemGroup` method in the `ItemGroupController`, `IItemGroupService`, and `ItemGroupService` classes, as well as updates to the corresponding unit tests. The changes aim to modify the way item group properties are patched by allowing individual properties to be updated rather than requiring the entire item group object.

The most important changes include:

### Controller Changes:
* [`V2/Cargohub/controllers/ItemGroupController.cs`](diffhunk://#diff-11675716a4769fb95380622dce337edae578ca1fa9c786f9549525ba6e68961aL144-R144): Modified the `PatchItemGroup` method to accept a property name and new value for patching instead of an entire `ItemGroupCS` object. Added validation to ensure the property and new value are not null. [[1]](diffhunk://#diff-11675716a4769fb95380622dce337edae578ca1fa9c786f9549525ba6e68961aL144-R144) [[2]](diffhunk://#diff-11675716a4769fb95380622dce337edae578ca1fa9c786f9549525ba6e68961aL160-R165)

### Service Interface Changes:
* [`V2/Cargohub/services/IItemGroupService.cs`](diffhunk://#diff-8afcf3fdad9b6860790d08aa8754812af9d7027d66eb84fb4ee23e2fe7c2408eL16-R16): Updated the `PatchItemGroup` method signature to accept a property name and new value.

### Service Implementation Changes:
* [`V2/Cargohub/services/ItemGroupService.cs`](diffhunk://#diff-9ab1a427c59459cd31067519da2de5e390255e1a15e0622db94d77fdb0f90585L129-R132): Modified the `PatchItemGroup` method to update only the specified property of the item group and handle cases where the property does not exist. [[1]](diffhunk://#diff-9ab1a427c59459cd31067519da2de5e390255e1a15e0622db94d77fdb0f90585L129-R132) [[2]](diffhunk://#diff-9ab1a427c59459cd31067519da2de5e390255e1a15e0622db94d77fdb0f90585R143-L145)

### Unit Test Changes:
* [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7L336-R340): Updated the `PatchItemGroupTest_Success` and `PatchItemGroupTest_NotFound` tests to reflect the new method signature and behavior. Removed assertions for the description property in the success test. [[1]](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7L336-R340) [[2]](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7L352-R352) [[3]](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7L361) [[4]](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7L382-R381)