### PR TITLE
Orders pytest create in v1 get & delete in v2 #445

### DIFF
--- a/PythonTests/test_Orders.py
+++ b/PythonTests/test_Orders.py
@@ -261,8 +261,6 @@ class TestOrdersAPI(unittest.TestCase):
                 "total_discount": 150.77,
                 "total_tax": 372.72,
                 "total_surcharge": 77.6,
-                "created_at": "2019-04-03T11:33:15Z",
-                "updated_at": "2019-04-05T07:33:15Z",
                 "items": [
                     {
                         "item_id": "P000002",

--- a/V2/Cargohub/controllers/ShipmentController.cs
+++ b/V2/Cargohub/controllers/ShipmentController.cs
@@ -136,7 +136,8 @@ public class ShipmentController : ControllerBase
 
         // Pagination logic
         int totalPages = (int)Math.Ceiling(filteredShipmentsCount / (double)pageSize);
-        if (page <= 0){
+        if (page <= 0)
+        {
             page = totalPages;
         }
         page = Math.Max(1, Math.Min(page, totalPages));


### PR DESCRIPTION
This pull request involves significant updates to the `PythonTests/test_Orders.py` file, particularly focusing on the removal of an order validation function and the addition of a new test case to ensure compatibility between API versions.

Key changes include:

### Removal of Order Validation Function:
* The `checkOrder` function, which validated the completeness of an order by checking the presence of various fields, has been removed.

### Addition of New Test Case:
* A new test case, `test_09_create_in_v1_get_and_delete_in_v2`, has been added. This test case performs the following operations:
  * Creates an order using API version 1.
  * Retrieves the created order using API version 2 to ensure compatibility.
  * Verifies that the retrieved order data matches the created data.
  * Deletes the order using API version 2.