### PR TITLE
Shipments pytest create in v1 get & delete in v2 

### DIFF
--- a/PythonTests/test_Shipments.py
+++ b/PythonTests/test_Shipments.py
@@ -224,3 +224,82 @@ class TestClass(unittest.TestCase):
                 headers=self.headers
             )
             self.assertEqual(response.status_code, 200)
+            
+    def test_10_create_in_v1_get_and_delete_in_v2(self):
+        # Create shipment in v1
+        version_v1 = "http://localhost:5001/api/v1"
+        data = {
+            "order_id": 1,
+            "source_id": 1,
+            "order_date": "2023-01-01T00:00:00Z",
+            "request_date": "2023-01-01T00:00:00Z",
+            "shipment_date": "2023-01-01T00:00:00Z",
+            "shipment_type": "TypeA",
+            "shipment_status": "Pending",
+            "notes": "Test shipment for cross-version",
+            "carrier_code": "CARRIER123",
+            "carrier_description": "Carrier Description",
+            "service_code": "SERVICE123",
+            "payment_type": "Prepaid",
+            "transfer_mode": "Air",
+            "total_package_count": 3,
+            "total_package_weight": 10.5,
+            "items": [
+                {
+                    "item_id": "P000002",
+                    "amount": 2
+                },
+                {
+                    "item_id": "P000004",
+                    "amount": 1
+                },
+                {
+                    "item_id": "P000006",
+                    "amount": 5
+                }
+            ]
+        }
+        response = self.client.post(
+            url=(version_v1 + "/shipments"),
+            headers=self.headers, json=data
+        )
+        self.assertEqual(response.status_code, 201)
+        shipment_id = response.json()["id"]
+
+        # Get shipment in v2
+        version_v2 = "http://localhost:5002/api/v2"
+        response = self.client.get(
+            url=(version_v2 + f"/shipments/{shipment_id}"),
+            headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Check all data in the get response
+        shipment_data = response.json()
+        self.assertEqual(shipment_data["order_id"], data["order_id"])
+        self.assertEqual(shipment_data["source_id"], data["source_id"])
+        self.assertEqual(shipment_data["order_date"], data["order_date"])
+        self.assertEqual(shipment_data["request_date"], data["request_date"])
+        self.assertEqual(shipment_data["shipment_date"], data["shipment_date"])
+        self.assertEqual(shipment_data["shipment_type"], data["shipment_type"])
+        self.assertEqual(shipment_data["shipment_status"],
+                         data["shipment_status"])
+        self.assertEqual(shipment_data["notes"], data["notes"])
+        self.assertEqual(shipment_data["carrier_code"], data["carrier_code"])
+        self.assertEqual(shipment_data["carrier_description"],
+                         data["carrier_description"])
+        self.assertEqual(shipment_data["service_code"], data["service_code"])
+        self.assertEqual(shipment_data["payment_type"], data["payment_type"])
+        self.assertEqual(shipment_data["transfer_mode"], data["transfer_mode"])
+        self.assertEqual(shipment_data["total_package_count"],
+                         data["total_package_count"])
+        self.assertEqual(shipment_data["total_package_weight"],
+                         data["total_package_weight"])
+        self.assertEqual(shipment_data["items"], data["items"])
+
+        # Delete shipment in v2
+        response = self.client.delete(
+            url=(version_v2 + f"/shipments/{shipment_id}"),
+            headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This pull request adds a new test case to the `PythonTests/test_Shipments.py` file. The new test case validates the creation of a shipment in version 1 of the API, retrieving it in version 2, and then deleting it in version 2 to ensure cross-version compatibility.

The most important change includes:

* Added a new test case `test_10_create_in_v1_get_and_delete_in_v2` to validate the creation, retrieval, and deletion of a shipment across different API versions (`v1` and `v2`). This test ensures that a shipment created in `v1` can be accessed and deleted in `v2`.