### PR TITLE
created the delete APIkey endpoint

### DIFF
--- a/V2/Cargohub/controllers/AdminController.cs
+++ b/V2/Cargohub/controllers/AdminController.cs
@@ -143,4 +143,35 @@ public class AdminController : ControllerBase
             return StatusCode(400, new { error = "An error occurred while updating the API keys.", details = ex.Message });
         }
     }
+
+    // Delete request to delete the API keys
+    [HttpDelete("DeleteAPIKeys")]
+    public IActionResult DeleteAPIKeys([FromQuery]string ApiKey)
+    {
+        // Allowed roles
+        List<string> listOfAllowedRoles = new List<string>() { "Admin" };
+        var userRole = HttpContext.Items["UserRole"]?.ToString();
+
+        // Authorization check
+        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        {
+            return Unauthorized("You are not authorized to delete API keys.");
+        }
+
+        try
+        {
+            var deletedKey = _adminservice.DeleteAPIKeys(ApiKey);
+            if (deletedKey == null)
+            {
+                return BadRequest(new { error = "API Key deletion failed" });
+            }
+            return Ok(new { message = "API Key deleted successfully", deletedKey });
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(400, new { error = "An error occurred while deleting the API keys.", details = ex.Message });
+        }
+    }
+
+
 }

--- a/V2/Cargohub/services/AdminService.cs
+++ b/V2/Cargohub/services/AdminService.cs
@@ -130,4 +130,19 @@ public class AdminService : IAdminService
         return key;
     }
 
+    public ApiKeyModel DeleteAPIKeys(string ApiKey)
+    {
+        var apiKeysPath = Path.Combine(Directory.GetCurrentDirectory(),"..","..", "apikeys.json");
+        // Get all the apikeys
+        var ListApiKeys = _apikeystorage.GetApiKeys();
+        // find where the apisecret is stored and then change the apikeys
+        var key = ListApiKeys.FirstOrDefault(k => k.Key == ApiKey);
+        if (key == null)
+        {
+            throw new Exception("API Key not found.");
+        }
+        ListApiKeys.Remove(key);
+        _apikeystorage.UpdateApiKey(ListApiKeys);
+        return key;
+    }
 }

--- a/V2/Cargohub/services/IAdminService.cs
+++ b/V2/Cargohub/services/IAdminService.cs
@@ -5,4 +5,5 @@ public interface IAdminService
     string AddData(IFormFile file);
     string GenerateReport();
     ApiKeyModel UpdateAPIKeys(string ApiKey, ApiKeyModel NewApiKey);
+    ApiKeyModel DeleteAPIKeys(string ApiKey);
 }

--- a/V2/tests/AdminTests.cs
+++ b/V2/tests/AdminTests.cs
@@ -86,6 +86,64 @@ namespace clients.TestsV2
             Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult));
         }
 
+        [TestMethod]
+        public void TestDeleteAPIKeys_Success()
+        {
+            // Arrange
+            var apiKey = "AnalystKey";
+
+            _mockAdminService
+                .Setup(service => service.DeleteAPIKeys(apiKey))
+                .Returns(new ApiKeyModel
+                {
+                    Key = "AnalystKey",
+                    Role = "Analyst",
+                    WarehouseID = "1,2,3"
+                });
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin"; // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _adminController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _adminController.DeleteAPIKeys(apiKey);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(OkObjectResult));
+            _mockAdminService.Verify(service => service.DeleteAPIKeys(apiKey), Times.Once);
+        }
+        
+        [TestMethod]
+        public void TestDeleteAPIKeys_Failed()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin"; // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _adminController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //arrange
+            var apiKey = "FAIL";
+
+            _mockAdminService
+                .Setup(service => service.DeleteAPIKeys(apiKey))
+                .Returns((ApiKeyModel)null);
+
+            // Act
+            var result = _adminController.DeleteAPIKeys(apiKey);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult));
+            _mockAdminService.Verify(service => service.DeleteAPIKeys(apiKey), Times.Once);
+        }
 
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to delete API keys in the `AdminController` and includes corresponding service and test updates. The most important changes are listed below:

### New Feature: Delete API Keys

* [`V2/Cargohub/controllers/AdminController.cs`](diffhunk://#diff-5cec75d5797bd939833e7dc967bd5df729480d78a12f2dad24b7bf5a808c03d2R146-R176): Added a new `DeleteAPIKeys` endpoint that allows deletion of API keys, with authorization checks for the "Admin" role.
* [`V2/Cargohub/services/AdminService.cs`](diffhunk://#diff-b99f7b123c3797b85fa1b95bc5bf12e93bc77b6241af3c5020f9e4e8aaec6129R133-R147): Implemented the `DeleteAPIKeys` method to remove API keys from the storage.
* [`V2/Cargohub/services/IAdminService.cs`](diffhunk://#diff-728a85f237c4c3aaa4608605d388cf85d427ee2d6f9ab131b511c15a2a9c7b7aR8): Updated the `IAdminService` interface to include the `DeleteAPIKeys` method.

### Testing

* [`V2/tests/AdminTests.cs`](diffhunk://#diff-ee7c98d0fd27571b0f66b9c34630947236bb28d82f68b319c2155d3f25f101ffR89-R146): Added unit tests for the `DeleteAPIKeys` method, including both success and failure scenarios.