### PR TITLE
created a endpoint that creates apikeys

### DIFF
--- a/V2/Cargohub/controllers/AdminController.cs
+++ b/V2/Cargohub/controllers/AdminController.cs
@@ -115,6 +115,35 @@ public class AdminController : ControllerBase
         }
     }
 
+    // post request to add API keys
+    [HttpPost("AddAPIKeys")]
+    public IActionResult AddAPIKeys([FromBody]ApiKeyModel ApiKey)
+    {
+        // Allowed roles
+        List<string> listOfAllowedRoles = new List<string>() { "Admin" };
+        var userRole = HttpContext.Items["UserRole"]?.ToString();
+
+        // Authorization check
+        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        {
+            return Unauthorized("You are not authorized to add API keys.");
+        }
+
+        try
+        {
+            var newKey = _adminservice.AddAPIKeys(ApiKey);
+            if (newKey == null)
+            {
+                return BadRequest(new { error = "API Key addition failed" });
+            }
+            return Ok(newKey);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(400, new { error = "An error occurred while adding the API keys.", details = ex.Message });
+        }
+    }
+
     // put request to update the API keys
     [HttpPut("UpdateAPIKeys")]
     public IActionResult UpdateAPIKeys([FromQuery]string ApiKey,[FromBody]ApiKeyModel NewApiKey)

--- a/V2/Cargohub/services/AdminService.cs
+++ b/V2/Cargohub/services/AdminService.cs
@@ -111,6 +111,16 @@ public class AdminService : IAdminService
 
         return report;
     }
+    public ApiKeyModel AddAPIKeys(ApiKeyModel ApiKey)
+    {
+        var apiKeysPath = Path.Combine(Directory.GetCurrentDirectory(),"..","..", "apikeys.json");
+        // Get all the apikeys
+        var ListApiKeys = _apikeystorage.GetApiKeys();
+        // Add the new apikey
+        ListApiKeys.Add(ApiKey);
+        _apikeystorage.UpdateApiKey(ListApiKeys);
+        return ApiKey;
+    }
 
     public ApiKeyModel UpdateAPIKeys(string OldApiKey, ApiKeyModel NewApiKey)
     {

--- a/V2/Cargohub/services/IAdminService.cs
+++ b/V2/Cargohub/services/IAdminService.cs
@@ -5,4 +5,5 @@ public interface IAdminService
     string AddData(IFormFile file);
     string GenerateReport();
     ApiKeyModel UpdateAPIKeys(string ApiKey, ApiKeyModel NewApiKey);
+    ApiKeyModel AddAPIKeys(ApiKeyModel ApiKey);
 }

--- a/V2/tests/AdminTests.cs
+++ b/V2/tests/AdminTests.cs
@@ -85,7 +85,70 @@ namespace clients.TestsV2
             // Assert
             Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult));
         }
+        
+        [TestMethod]
+        public void TestAddAPIKeys_Success()
+        {
+            // Arrange
+            var newApiKey = new ApiKeyModel
+            {
+                Key = "AnalystKey",
+                Role = "Analyst",
+                WarehouseID = "1,2,3"
+            };
 
+            _mockAdminService
+                .Setup(service => service.AddAPIKeys(newApiKey))
+                .Returns(newApiKey); // Set up the mock service behavior
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _adminController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _adminController.AddAPIKeys(newApiKey);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(OkObjectResult));
+            _mockAdminService.Verify(service => service.AddAPIKeys(newApiKey), Times.Once);
+        }
+
+        [TestMethod]
+        public void TestAddAPIKeys_Failed()
+        {
+            // Arrange
+            var newApiKey = new ApiKeyModel
+            {
+                Key = "AnalystKey",
+                Role = "Analyst",
+                WarehouseID = "1,2,3"
+            };
+
+            // Mock the AddAPIKeys method to simulate failure
+            _mockAdminService
+                .Setup(service => service.AddAPIKeys(newApiKey))
+                .Returns((ApiKeyModel)null);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin"; // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _adminController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _adminController.AddAPIKeys(newApiKey);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult));
+        }
 
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to add API keys in the `AdminController` and includes corresponding changes in the service layer and tests. The most important changes include adding a new endpoint for adding API keys, updating the service to handle the addition of API keys, and adding unit tests for this new functionality.

### New Feature: Add API Keys

* [`V2/Cargohub/controllers/AdminController.cs`](diffhunk://#diff-5cec75d5797bd939833e7dc967bd5df729480d78a12f2dad24b7bf5a808c03d2R118-R146): Added a new `AddAPIKeys` endpoint to allow authorized users to add API keys. This includes authorization checks and error handling.
* [`V2/Cargohub/services/AdminService.cs`](diffhunk://#diff-b99f7b123c3797b85fa1b95bc5bf12e93bc77b6241af3c5020f9e4e8aaec6129R114-R123): Implemented the `AddAPIKeys` method to add new API keys to the storage.
* [`V2/Cargohub/services/IAdminService.cs`](diffhunk://#diff-728a85f237c4c3aaa4608605d388cf85d427ee2d6f9ab131b511c15a2a9c7b7aR8): Updated the `IAdminService` interface to include the `AddAPIKeys` method.

### Unit Tests

* [`V2/tests/AdminTests.cs`](diffhunk://#diff-ee7c98d0fd27571b0f66b9c34630947236bb28d82f68b319c2155d3f25f101ffR89-R151): Added unit tests `TestAddAPIKeys_Success` and `TestAddAPIKeys_Failed` to verify the functionality and error handling of the `AddAPIKeys` endpoint.