### PR TITLE
Update ClientTests.cs

### DIFF
--- a/V2/Cargohub/controllers/ClientController.cs
+++ b/V2/Cargohub/controllers/ClientController.cs
@@ -142,8 +142,18 @@ public class ClientController : ControllerBase
     }
 
     [HttpDelete("batch")]
-    public ActionResult DeleteClients ([FromBody] List<int> ids){
-        if(ids is null){
+    public ActionResult DeleteClients([FromBody] List<int> ids)
+    {
+        List<string> listOfAllowedRoles = new List<string>() { "Admin" };
+        var userRole = HttpContext.Items["UserRole"]?.ToString();
+
+        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        {
+            return Unauthorized();
+        }
+        
+        if (ids is null)
+        {
             return BadRequest("error in request");
         }
         _clientservice.DeleteClients(ids);
@@ -175,5 +185,5 @@ public class ClientController : ControllerBase
         }
 
         return Ok(updatedClient);
-    }    
+    }
 }

--- a/V2/tests/ClientTests.cs
+++ b/V2/tests/ClientTests.cs
@@ -301,7 +301,7 @@ namespace clients.TestsV2
             };
             result = _clientController.DeleteClient(1);
 
-            var unauthorizedResult = result.Result as UnauthorizedResult;
+            var unauthorizedResult = result as UnauthorizedResult;
             Assert.IsNotNull(unauthorizedResult);
             Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
@@ -337,10 +337,9 @@ namespace clients.TestsV2
             {
                 HttpContext = httpContext
             };
-            result = _clientController.DeleteClients(clientsToDelete);
+            var resultUn = _clientController.DeleteClients(clientsToDelete);
 
-            var unauthorizedResult = result.Result as UnauthorizedResult;
-            Assert.IsNotNull(unauthorizedResult);
+            var unauthorizedResult = resultUn as UnauthorizedResult;
             Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 

--- a/V2/tests/ClientTests.cs
+++ b/V2/tests/ClientTests.cs
@@ -49,6 +49,20 @@ namespace clients.TestsV2
             var returnedItems = okResult.Value as IEnumerable<ClientCS>;
             Assert.IsNotNull(okResult);
             Assert.AreEqual(2, returnedItems.Count());
+
+            httpContext.Items["UserRole"] = "Operative";
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            result = _clientController.GetAllClients();
+
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -74,7 +88,25 @@ namespace clients.TestsV2
             var resultok = result.Result as OkObjectResult;
             Assert.IsNotNull(resultok);
             Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+
+            httpContext.Items["UserRole"] = "Operative";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            result = _clientController.GetClientById(1);
+
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
+
+        
 
         [TestMethod]
         public void CreateClient_ReturnsCreatedResult_WithNewClient()
@@ -104,6 +136,19 @@ namespace clients.TestsV2
             Assert.IsNotNull(returnedClients);
             Assert.AreEqual(client.Address, returnedClients.Address);
             Assert.AreEqual(client.City, returnedClients.City);
+
+            httpContext.Items["UserRole"] = "Operative";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            result = _clientController.CreateClient(client);
+
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -140,6 +185,19 @@ namespace clients.TestsV2
             Assert.AreEqual(clients[0].Address, firstClient.Address);
             Assert.AreEqual(clients[0].contact_phone, firstClient.contact_phone);
             Assert.AreEqual(clients[0].contact_name, firstClient.contact_name);
+
+            httpContext.Items["UserRole"] = "Operative";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            result = _clientController.CreateMultipleClients(clients);
+
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -170,6 +228,19 @@ namespace clients.TestsV2
             var returnedClient = createdResult.Value as ClientCS;
             Assert.AreEqual(updatedClient.City, returnedClient.City);
             Assert.AreEqual(updatedClient.Address, returnedClient.Address);
+
+            httpContext.Items["UserRole"] = "Operative";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            result = _clientController.UpdateClient(1, updatedClient);
+
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -220,6 +291,19 @@ namespace clients.TestsV2
 
             // Assert
             Assert.IsInstanceOfType(result, typeof(OkResult));
+
+            httpContext.Items["UserRole"] = "Operative";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            result = _clientController.DeleteClient(1);
+
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
 
@@ -245,6 +329,19 @@ namespace clients.TestsV2
             //Assert
             Assert.IsInstanceOfType(result, typeof(OkObjectResult));
             Assert.AreEqual(resultOK.StatusCode, 200);
+
+            httpContext.Items["UserRole"] = "Operative";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            result = _clientController.DeleteClients(clientsToDelete);
+
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -277,6 +374,19 @@ namespace clients.TestsV2
             Assert.IsNotNull(returnedClient);
             Assert.AreEqual(patchClient.Address, returnedClient.Address);
             Assert.AreEqual(patchClient.City, returnedClient.City);
+
+            httpContext.Items["UserRole"] = "Operative";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            result = _clientController.PatchClient(1, "address", "new street");
+            
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]


### PR DESCRIPTION
This pull request includes several updates to the `ClientTests` in the `V2/tests/ClientTests.cs` file to add authorization checks. The changes ensure that an unauthorized result is returned when the `UserRole` is set to "Operative" in the `HttpContext`.

Authorization checks added to tests:

* [`GetAllClients_Test_returns_true()`](diffhunk://#diff-c6ad61f58fb4d4f49de621acc3371472b3d8c7723b77535b49cecfe9c0855518R52-R65): Added code to set `UserRole` in `HttpContext` and verify that an unauthorized result is returned.
* [`GetClientById_Test_returns_true()`](diffhunk://#diff-c6ad61f58fb4d4f49de621acc3371472b3d8c7723b77535b49cecfe9c0855518R91-R110): Added code to set `UserRole` in `HttpContext` and verify that an unauthorized result is returned.
* [`CreateClient_ReturnsCreatedResult_WithNewClient()`](diffhunk://#diff-c6ad61f58fb4d4f49de621acc3371472b3d8c7723b77535b49cecfe9c0855518R139-R151): Added code to set `UserRole` in `HttpContext` and verify that an unauthorized result is returned.
* [`CreateMultipleClient_ReturnsCreatedResult_WithNewClient()`](diffhunk://#diff-c6ad61f58fb4d4f49de621acc3371472b3d8c7723b77535b49cecfe9c0855518R188-R200): Added code to set `UserRole` in `HttpContext` and verify that an unauthorized result is returned.
* [`UpdatedClientTest_Success()`](diffhunk://#diff-c6ad61f58fb4d4f49de621acc3371472b3d8c7723b77535b49cecfe9c0855518R231-R243): Added code to set `UserRole` in `HttpContext` and verify that an unauthorized result is returned.
* [`DeleteClientTest_Success()`](diffhunk://#diff-c6ad61f58fb4d4f49de621acc3371472b3d8c7723b77535b49cecfe9c0855518R294-R306): Added code to set `UserRole` in `HttpContext` and verify that an unauthorized result is returned.
* [`DeleteClientsTest_Succes()`](diffhunk://#diff-c6ad61f58fb4d4f49de621acc3371472b3d8c7723b77535b49cecfe9c0855518R332-R344): Added code to set `UserRole` in `HttpContext` and verify that an unauthorized result is returned.
* [`PatchClientTest_Success()`](diffhunk://#diff-c6ad61f58fb4d4f49de621acc3371472b3d8c7723b77535b49cecfe9c0855518R377-R389): Added code to set `UserRole` in `HttpContext` and verify that an unauthorized result is returned.