### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,17 +155,19 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
-    - name: Build for Linux
-      run: |
-        dotnet publish ./V1/Cargohub/Werehouses.csproj -c Release -r linux-x64 --self-contained false -o ./publish
-        dotnet publish ./V2/Cargohub/Werehouses.csproj -c Release -r linux-x64 --self-contained false -o ./publish
-
+  
+    - name: Build V1 for Linux
+      run: dotnet publish ./V1/Cargohub/Werehouses.csproj -c Release -r linux-x64 --self-contained false -o ./publish/V1
+  
+    - name: Build V2 for Linux
+      run: dotnet publish ./V2/Cargohub/Werehouses.csproj -c Release -r linux-x64 --self-contained false -o ./publish/V2
+  
     - name: Create ZIP package
       run: zip -r linux-release-v${{ github.run_number }}.zip ./publish
-
+  
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v4
       with:
         name: linux-release-v${{ github.run_number }}
         path: linux-release-v${{ github.run_number }}.zip
+


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yml` file to improve the build process for Linux. The most important changes include separating the build steps for V1 and V2, and creating distinct output directories for each version.

Improvements to build process:

* Separated the build steps for V1 and V2, creating distinct steps for each version. This change ensures that each version is built independently, reducing the risk of conflicts and improving clarity.
* Updated the output directories for the build steps to `./publish/V1` and `./publish/V2` respectively, ensuring that the builds are organized and easier to manage.

Simplification:

* Added a newline after the `path` configuration in the `Create ZIP package` step for better readability.