### PR TITLE
added the unauthorized checks for the itemgroups

### DIFF
--- a/V2/tests/ItemGroupTests.cs
+++ b/V2/tests/ItemGroupTests.cs
@@ -50,6 +50,20 @@ namespace itemgroup.TestsV2
             // Assert
             Assert.IsNotNull(okResult);
             Assert.AreEqual(2, returnedItems.Count());
+
+            httpContext.Items["UserRole"] = "NoRole";
+            _itemGroupController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            result = _itemGroupController.GetAllItemGroups();
+
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -77,6 +91,20 @@ namespace itemgroup.TestsV2
             Assert.IsNotNull(okResult);
             Assert.IsNotNull(okResult.Value);
             Assert.AreEqual(itemGroup.Name, returnedItem.Name);
+
+            httpContext.Items["UserRole"] = "NoRole";
+            _itemGroupController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            result = _itemGroupController.GetItemById(1);
+
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -125,6 +153,20 @@ namespace itemgroup.TestsV2
             // Assert
             Assert.IsNotNull(createdResult);
             Assert.AreEqual(newItemGroup.Name, returnedItem.Name);
+
+            httpContext.Items["UserRole"] = "NoRole";
+            _itemGroupController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            var value = _itemGroupController.GetItemById(1);
+
+            //assert
+            var unauthorizedResult = value.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -158,6 +200,20 @@ namespace itemgroup.TestsV2
             Assert.IsNotNull(returnedItems);
             Assert.AreEqual(itemGroups[0].Name, firstItemGroup.Name);
             Assert.AreEqual(itemGroups[0].Description, firstItemGroup.Description);
+
+            httpContext.Items["UserRole"] = "NoRole";
+            _itemGroupController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            result = _itemGroupController.CreateMultipleItemGroups(itemGroups);
+
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -186,6 +242,20 @@ namespace itemgroup.TestsV2
             // Assert
             Assert.IsNotNull(okResult);
             Assert.AreEqual(updatedItemGroup.Description, returnedItem.Description);
+
+            httpContext.Items["UserRole"] = "NoRole";
+            _itemGroupController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            var result = _itemGroupController.UpdateItemGroup(1, updatedItemGroup);
+
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -255,6 +325,20 @@ namespace itemgroup.TestsV2
             //assert
             Assert.IsInstanceOfType(result, typeof(OkResult));
 
+            httpContext.Items["UserRole"] = "NoRole";
+            _itemGroupController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            result = _itemGroupController.DeleteItemGroup(1);
+
+            //assert
+            var unauthorizedResult = result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
+
         }
 
         [TestMethod]
@@ -303,6 +387,20 @@ namespace itemgroup.TestsV2
             Assert.IsNotNull(value);
             Assert.IsInstanceOfType(value, typeof(List<ItemCS>));
             Assert.AreEqual(value[0].item_group, 1);
+
+            httpContext.Items["UserRole"] = "NoRole";
+            _itemGroupController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            var unAuth = _itemGroupController.GetAllItemsFromItemGroupId(1);
+
+            //assert
+            var unauthorizedResult = unAuth.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -327,6 +425,20 @@ namespace itemgroup.TestsV2
             //Assert
             Assert.IsInstanceOfType(result, typeof(OkObjectResult));
             Assert.AreEqual(resultok.StatusCode, 200);
+
+            httpContext.Items["UserRole"] = "NoRole";
+            _itemGroupController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            var value = _itemGroupController.DeleteItemGroups(itemgroupsToDelete);
+
+            //assert
+            var unauthorizedResult = value as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -358,6 +470,20 @@ namespace itemgroup.TestsV2
             Assert.IsNotNull(okResult);
             Assert.IsInstanceOfType(okResult.Value, typeof(ItemGroupCS));
             Assert.AreEqual(patchItemGroup.Name, returnedItemGroup.Name);
+
+            httpContext.Items["UserRole"] = "NoRole";
+            _itemGroupController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            var value = _itemGroupController.PatchItemGroup(1, "Name", "Updated Group");
+
+            //assert
+            var unauthorizedResult = value.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]


### PR DESCRIPTION
This pull request introduces additional test cases to ensure that unauthorized access is properly handled in the `ItemGroupController` methods. Each test case now includes a scenario where the user role is set to "NoRole" to verify that the controller returns a 401 Unauthorized status code.

Key changes include:

* **Unauthorized Access Tests:**
  * [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R53-R66): Added unauthorized access test to `GetAllItemGroupsTest_Exists()` to check for 401 status code when user role is "NoRole".
  * [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R94-R107): Added unauthorized access test to `GetItemGroupByIdTest_Exists()` to verify 401 status code when user role is "NoRole".
  * [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R156-R169): Included unauthorized access test in `CreateItemGroupTest_Success()` to ensure 401 status code is returned when user role is "NoRole".
  * [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R203-R216): Added unauthorized access test to `CreateMultipleItemGroups_ReturnsCreatedResult_WithNewGroups()` to check for 401 status code when user role is "NoRole".
  * [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R245-R258): Included unauthorized access test in `UpdateItemGroupTest_ValidItem()` to verify 401 status code when user role is "NoRole".
  * [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R328-R341): Added unauthorized access test to `DeleteItemGroupTest_Exists()` to ensure 401 status code is returned when user role is "NoRole".
  * [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R390-R403): Included unauthorized access test in `ItemsFromItemGroupId_Succes()` to verify 401 status code when user role is "NoRole".
  * [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R428-R441): Added unauthorized access test to `DeleteItemGroups_Succes()` to check for 401 status code when user role is "NoRole".
  * [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R473-R486): Included unauthorized access test in `PatchItemGroupTest_Success()` to ensure 401 status code is returned when user role is "NoRole".