### PR TITLE
466 adding unauthorized testing warehouse

### DIFF
--- a/V2/Cargohub/controllers/WarehouseController.cs
+++ b/V2/Cargohub/controllers/WarehouseController.cs
@@ -214,6 +214,13 @@ public class WarehouseController : ControllerBase
     //''   :     ''   /  ''/      contact == werkt niet
     [HttpPatch("{id}")]
     public ActionResult<WarehouseCS> PatchWarehouse([FromRoute] int id, [FromQuery] string property, [FromBody] object newvalue){
+        List<string> listOfAllowedRoles = new List<string>() { "Admin" };
+        var userRole = HttpContext.Items["UserRole"]?.ToString();
+
+        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        {
+            return Unauthorized();
+        }
         if(newvalue is null){
             return NotFound("Erhm what?");
         }

--- a/V2/tests/WarehouseTests.cs
+++ b/V2/tests/WarehouseTests.cs
@@ -49,6 +49,21 @@ namespace TestsV2
             var returnedItems = okResult.Value as PaginationCS<WarehouseCS>;
             Assert.IsNotNull(okResult);
             Assert.AreEqual(2, returnedItems.Data.Count());
+
+            httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.GetAllWarehouses(null, 1, 10);
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -80,6 +95,20 @@ namespace TestsV2
             Assert.IsNotNull(okResult);
             Assert.IsNotNull(okResult.Value);
             Assert.AreEqual(warehouses[0].Address, returnedItems.Address);
+                        httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.GetWarehouseById(1);
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -102,6 +131,21 @@ namespace TestsV2
 
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+
+                        httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.GetWarehouseById(1);
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -131,6 +175,21 @@ namespace TestsV2
             var returnedItems = createdResult.Value as WarehouseCS;
             Assert.IsNotNull(returnedItems);
             Assert.AreEqual(warehouse.Address, returnedItems.Address);
+
+            httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.CreateWarehouse(warehouse);
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -168,6 +227,21 @@ namespace TestsV2
             Assert.IsNotNull(returnedItems);
             Assert.AreEqual(warehouses[0].Address, firstWarehouse.Address);
             Assert.AreEqual(warehouses[0].Contact, firstWarehouse.Contact);
+
+            httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.CreateMultipleWarehouse(warehouses);
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -209,6 +283,21 @@ namespace TestsV2
             var returnedWarehouse = createdResult.Value as WarehouseCS;
             Assert.AreEqual(updatedWarehouse.Code, returnedWarehouse.Code);
             Assert.AreEqual(updatedWarehouse.Address, returnedWarehouse.Address);
+
+            httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.UpdateWarehouse(1, updatedWarehouse);
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -247,10 +336,33 @@ namespace TestsV2
             var createdResult = result.Result as NotFoundObjectResult;
             var returnedWarehouse = createdResult.Value as WarehouseCS;
             Assert.IsNull(returnedWarehouse);
+
+            httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.UpdateWarehouse(0, updatedWarehouse);
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
         
         [TestMethod]
         public void PatchWarehouse_Succes(){
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";  // Set the UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
             //Arrange
             var warehouse = new WarehouseCS(){ Id = 1, Code= "LOLJK", Name="KOPLER"};
             _mockWarehouseService.Setup(service=>service.PatchWarehouse(1, "Code", "LOLJK")).Returns(warehouse);
@@ -274,6 +386,21 @@ namespace TestsV2
             Assert.AreEqual(result2ok.StatusCode, 200);
             Assert.AreEqual(result1value.Code, warehouse.Code);
             Assert.AreEqual(result2value.Name, warehouse.Name);
+
+            httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            var result = _warehouseController.PatchWarehouse(1, "Code", "LOLJK");
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
         [TestMethod]
         public void DeleteWarehouseTest_Success()
@@ -296,6 +423,21 @@ namespace TestsV2
 
             // Assert
             Assert.IsInstanceOfType(result, typeof(OkResult));
+
+            httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.DeleteWarehouse(1);
+            //assert
+            var unauthorizedResult = result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
         [TestMethod]
         public void DeleteWarehousesTest_Succes()
@@ -319,6 +461,21 @@ namespace TestsV2
             //Assert
             Assert.IsInstanceOfType(result, typeof(OkObjectResult));
             Assert.AreEqual(resultok.StatusCode, 200);
+
+            httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.DeleteWarehouses(idsToDelete);
+            //assert
+            var unauthorizedResult = result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -346,6 +503,21 @@ namespace TestsV2
             Assert.IsNotNull(okResult);
             Assert.IsNotNull(returnedItems);
             Assert.AreEqual(warehouse.Address, returnedItems.Address);
+
+            httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.GetLatestUpdatedWarehouse();
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
         [TestMethod]
@@ -368,6 +540,21 @@ namespace TestsV2
 
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+
+            httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Client";  // Set the wrong UserRole in HttpContext
+
+            // Assign HttpContext to the controller
+            _warehouseController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+            //act
+            result = _warehouseController.GetLatestUpdatedWarehouse();
+            //assert
+            var unauthorizedResult = result.Result as UnauthorizedResult;
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces authorization checks for the `WarehouseController` and updates the corresponding unit tests to validate these changes. The main focus is ensuring that only users with the "Admin" role can perform certain actions on the warehouse resources.

Authorization checks:

* [`V2/Cargohub/controllers/WarehouseController.cs`](diffhunk://#diff-70ec61fbf0bac5d4101ed52879eb083dee641e8b7efd8bd175dd973951bcc78bR217-R223): Added a check to ensure that only users with the "Admin" role can access the `PatchWarehouse` method. If the user role is not "Admin", the method returns an `Unauthorized` response.

Unit test updates:

* [`V2/tests/WarehouseTests.cs`](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR52-R66): Updated various test methods to include scenarios where the user role is set to "Client" and verify that the actions return an `Unauthorized` response with a status code of 401. These methods include `GetWarehousesTest_Exists` [[1]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR52-R66) `GetWarehouseByIdTest_Exists` [[2]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR98-R111) `GetWarehouseByIdTest_WrongId` [[3]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR134-R148) `CreateWarehouse_ReturnsCreatedResult_WithNewWarehouse` [[4]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR178-R192) `CreateMultipleWarehouse_ReturnsCreatedResult_WithNewWarehouse` [[5]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR230-R244) `UpdatedWarehouseTest_Success` [[6]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR286-R300) `UpdatedWarehouseTest_Failed` [[7]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR339-R365) `PatchWarehouse_Succes` [[8]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR389-R403) `DeleteWarehouseTest_Success` [[9]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR426-R440) `DeleteWarehousesTest_Succes` [[10]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR464-R478) `GetLatestUpdatedWarehouseTest_Success` [[11]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR506-R520) and `GetLatestUpdatedWarehouseTest_Failed` [[12]](diffhunk://#diff-cd37b585a7d77a6542b907edbb2790975c6ccd4f46e494711e9f328a5352456eR543-R557).