### PR TITLE
475 item line unauthorized laten checken

### DIFF
--- a/V2/tests/ItemLineTests.cs
+++ b/V2/tests/ItemLineTests.cs
@@ -50,6 +50,20 @@ public class ItemLineTests
         // Assert
         Assert.IsNotNull(okResult);
         Assert.AreEqual(2, returnedItems.Count());
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        var result = _itemLineController.GetAllItemLines();
+
+        //assert
+        var unauthorizedResult = result.Result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
     [TestMethod]
@@ -77,6 +91,20 @@ public class ItemLineTests
         Assert.IsNotNull(okResult);
         Assert.IsNotNull(okResult.Value);
         Assert.AreEqual(itemLine.Description, returnedItem.Description);
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        var secondResult = _itemLineController.GetItemLineById(1);
+
+        //assert
+        var unauthorizedResult = secondResult.Result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
     [TestMethod]
@@ -99,6 +127,20 @@ public class ItemLineTests
 
         // Assert
         Assert.IsInstanceOfType(value.Result, typeof(NotFoundResult));
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        var result = _itemLineController.GetItemLineById(1);
+
+        //assert
+        var unauthorizedResult = result.Result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
     [TestMethod]
@@ -125,6 +167,20 @@ public class ItemLineTests
         // Assert
         Assert.IsNotNull(createdResult);
         Assert.AreEqual(newItemLine.Description, returnedItem.Description);
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        var result = _itemLineController.AddItemLine(newItemLine);
+
+        //assert
+        var unauthorizedResult = result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
     [TestMethod]
@@ -145,6 +201,20 @@ public class ItemLineTests
 
         // Assert
         Assert.IsInstanceOfType(createdResult, typeof(BadRequestObjectResult));
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        var result = _itemLineController.AddItemLine(null);
+
+        //assert
+        var unauthorizedResult = result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
     [TestMethod]
@@ -178,6 +248,20 @@ public class ItemLineTests
         Assert.IsNotNull(returnedItems);
         Assert.AreEqual(itemLines[0].Name, firstItemLine.Name);
         Assert.AreEqual(itemLines[0].Description, firstItemLine.Description);
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        result = _itemLineController.CreateMultipleItemLines(itemLines);
+
+        //assert
+        var unauthorizedResult = result.Result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
     [TestMethod]
@@ -206,6 +290,20 @@ public class ItemLineTests
         // Assert
         Assert.IsNotNull(okResult);
         Assert.AreEqual(updatedItemLine.Description, returnedItem.Description);
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        var result = _itemLineController.UpdateItemLine(1, updatedItemLine);
+
+        //assert
+        var unauthorizedResult = result.Result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
     [TestMethod]
@@ -274,6 +372,20 @@ public class ItemLineTests
 
         // Assert
         Assert.IsInstanceOfType(value, typeof(OkResult));
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        var result = _itemLineController.DeleteItemLine(1);
+
+        //assert
+        var unauthorizedResult = result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
 
@@ -311,6 +423,20 @@ public class ItemLineTests
         var returnedItems = okResult.Value as IEnumerable<ItemCS>;
         Assert.IsNotNull(returnedItems, "Expected returnedItems to be non-null.");
         Assert.AreEqual(2, returnedItems.Count(), "Expected returnedItems to contain 2 items.");
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        result = _itemLineController.GetItemsByItemLineId(1);
+
+        //assert
+        var unauthorizedResult = result.Result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
 
@@ -357,6 +483,20 @@ public class ItemLineTests
         //Assert
         Assert.IsInstanceOfType(result, typeof(OkObjectResult));
         Assert.AreEqual(resultok.StatusCode, 200);
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        var secondResult = _itemLineController.DeleteItemLine(1);
+
+        //assert
+        var unauthorizedResult = secondResult as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
     [TestMethod]
@@ -388,6 +528,20 @@ public class ItemLineTests
         Assert.IsNotNull(okResult);
         Assert.IsInstanceOfType(okResult.Value, typeof(ItemLineCS));
         Assert.AreEqual(patchItemLine.Description, returnedItemLine.Description);
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        var secondResult = _itemLineController.PatchItemLine(1, "Description", "Updated Description");
+
+        //assert
+        var unauthorizedResult = secondResult.Result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 
     [TestMethod]
@@ -412,5 +566,19 @@ public class ItemLineTests
 
         // Assert
         Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+
+        httpContext.Items["UserRole"] = "NoRole";
+        _itemLineController.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        //act
+        var secondResult = _itemLineController.PatchItemLine(1, "Description", "Updated Description");
+
+        //assert
+        var unauthorizedResult = secondResult.Result as UnauthorizedResult;
+        Assert.IsNotNull(unauthorizedResult);
+        Assert.AreEqual(401, unauthorizedResult.StatusCode);
     }
 }


### PR DESCRIPTION
This pull request adds new test scenarios to the `ItemLineTests` class in `V2/tests/ItemLineTests.cs` to verify the behavior of the `ItemLineController` when the user role is unauthorized. The changes ensure that appropriate unauthorized responses are returned when the user role is not permitted to perform certain actions.

New test scenarios for unauthorized access:

* Added checks in `GetItemLinesTest_Exists` to verify that the controller returns a 401 Unauthorized status when the user role is unauthorized.
* Updated `GetItemLineByIdTest_Exists` to include a scenario where an unauthorized user role results in a 401 Unauthorized status.
* Modified `GetItemLineByIdTest_WrongId` to test for unauthorized access and ensure a 401 Unauthorized status is returned.
* Added unauthorized user role checks in `AddItemLineTest_ValidItem` and `AddItemLineTest_NullItem` to confirm that a 401 Unauthorized status is returned. [[1]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R170-R183) [[2]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R204-R217)
* Included unauthorized access scenarios in `CreateMultipleWarehouse_ReturnsCreatedResult_WithNewWarehouse` and `UpdateItemLineTest_ValidItem` to verify 401 Unauthorized status responses. [[1]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R251-R264) [[2]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R293-R306)
* Added unauthorized user role checks in `DeleteItemLineTest_Exists` and `GetItemsByItemLineId_ExistingId` to ensure 401 Unauthorized status responses. [[1]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R375-R388) [[2]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R426-R439)
* Updated `DeleteItemLinesTest_Succes` and `PatchItemLineTest_Success` to include scenarios for unauthorized access, returning a 401 Unauthorized status. [[1]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R486-R499) [[2]](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R531-R544)
* Added unauthorized user role checks in `PatchItemLineTest_NotFound` to confirm that a 401 Unauthorized status is returned.