### PR TITLE
Removed all async with itemtype did all unauth tests

### DIFF
--- a/V2/Cargohub/controllers/ItemTypeController.cs
+++ b/V2/Cargohub/controllers/ItemTypeController.cs
@@ -122,33 +122,47 @@ public class ItemTypeController : ControllerBase
     }
 
     [HttpPut("{id}")]
-    public async Task<ActionResult<ItemTypeCS>> UpdateItemType(int id, [FromBody] ItemTypeCS itemType)
+    public ActionResult<ItemTypeCS> UpdateItemType(int id, [FromBody] ItemTypeCS itemType)
     {
         List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager", "Inventory Manager" };
         var userRole = HttpContext.Items["UserRole"]?.ToString();
 
+        // Check if the user is unauthorized
         if (userRole == null || !listOfAllowedRoles.Contains(userRole))
         {
             return Unauthorized();
         }
 
+        // Validate the ID in the request
         if (id != itemType.Id)
         {
             return BadRequest();
         }
 
-        var existingItemLine = _itemtypeService.GetItemById(id);
+        // Get the existing item by ID
+        var existingItemLine = _itemtypeService.GetItemById(id); // Assuming this is now a synchronous call
         if (existingItemLine == null)
         {
             return NotFound();
         }
 
-        var updatedItemLine = await _itemtypeService.UpdateItemType(id, itemType);
+        // Update the item synchronously
+        var updatedItemLine = _itemtypeService.UpdateItemType(id, itemType); // Assuming this is now a synchronous call
         return Ok(updatedItemLine);
     }
+
     //zet een nieuwe value in een property van een item_type object 
     [HttpPatch("{id}")]
     public ActionResult<ItemTypeCS> PatchItemType([FromRoute] int id, [FromQuery] string property, [FromBody] object newvalue){
+        List<string> listOfAllowedRoles = new List<string>() { "Admin", "Warehouse Manager", "Inventory Manager" };
+        var userRole = HttpContext.Items["UserRole"]?.ToString();
+
+        // Check if the user is unauthorized
+        if (userRole == null || !listOfAllowedRoles.Contains(userRole))
+        {
+            return Unauthorized();
+        }
+        
         if(int.IsNegative(id) || string.IsNullOrEmpty(property) || newvalue is null){
             return BadRequest("Errors in request");
         }

--- a/V2/Cargohub/services/IItemTypeService.cs
+++ b/V2/Cargohub/services/IItemTypeService.cs
@@ -9,7 +9,7 @@ public interface IItemtypeService
     ItemTypeCS GetItemById(int id);
     ItemTypeCS CreateItemType(ItemTypeCS newItemType);
     List<ItemTypeCS> CreateMultipleItemTypes(List<ItemTypeCS>newItemType);
-    Task<ItemTypeCS> UpdateItemType(int id, ItemTypeCS itemType);
+    ItemTypeCS UpdateItemType(int id, ItemTypeCS itemType);
     ItemTypeCS PatchItemType(int id, string property, object newvalue);
     void DeleteItemType(int id);
     void DeleteItemTypes(List<int> ids);

--- a/V2/Cargohub/services/ItemTypeService.cs
+++ b/V2/Cargohub/services/ItemTypeService.cs
@@ -69,7 +69,7 @@ public class ItemTypeService : IItemtypeService
     }
 
     // Method to update an item type
-    public async Task<ItemTypeCS> UpdateItemType(int id, ItemTypeCS itemType)
+    public ItemTypeCS UpdateItemType(int id, ItemTypeCS itemType)
     {
         List<ItemTypeCS> items = GetAllItemtypes();
         var existingItem = items.FirstOrDefault(i => i.Id == id);
@@ -89,10 +89,11 @@ public class ItemTypeService : IItemtypeService
         existingItem.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);
-        await File.WriteAllTextAsync(path, jsonData);
+        File.WriteAllText(path, jsonData); // Using the synchronous version
 
         return existingItem;
     }
+
     public ItemTypeCS PatchItemType(int id, string property, object newvalue){
         var formattednow = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
         var itemtypes = GetAllItemtypes();


### PR DESCRIPTION
This pull request includes several changes to the `ItemTypeController`, `IItemTypeService`, `ItemTypeService`, and related test files to improve authorization checks and switch from asynchronous to synchronous methods. The most important changes include updating the `UpdateItemType` method to be synchronous, adding authorization checks, and modifying the tests to reflect these changes.

Authorization checks:

* [`V2/Cargohub/controllers/ItemTypeController.cs`](diffhunk://#diff-5d508b0fe806e9b72bd622dbfbf7b983c878d74fa4159e6a1d856c90d2cb6cf5L125-R165): Added authorization checks to ensure that only users with specific roles can perform certain actions.

Switch from asynchronous to synchronous methods:

* [`V2/Cargohub/services/IItemTypeService.cs`](diffhunk://#diff-85298a48ac2f915a665208b2a493e3ac2f21ccdd4697858bd85906ccb99c0c95L12-R12): Changed the `UpdateItemType` method to be synchronous in the interface.
* [`V2/Cargohub/services/ItemTypeService.cs`](diffhunk://#diff-9a956ab1af1acbcf7493b60100ea979f6acc0c092da1ea6a1c84e510e2a28da5L72-R72): Updated the `UpdateItemType` method to be synchronous and used the synchronous version of `File.WriteAllText`. [[1]](diffhunk://#diff-9a956ab1af1acbcf7493b60100ea979f6acc0c092da1ea6a1c84e510e2a28da5L72-R72) [[2]](diffhunk://#diff-9a956ab1af1acbcf7493b60100ea979f6acc0c092da1ea6a1c84e510e2a28da5L92-R96)

Test modifications:

* [`V2/tests/ItemTypeTests.cs`](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R35-R42): Updated the tests to set the `UserRole` in the `HttpContext`, simulate unauthorized access, and reflect the synchronous nature of the `UpdateItemType` method. [[1]](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R35-R42) [[2]](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R51-R64) [[3]](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R88-R101) [[4]](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R128-R153) [[5]](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64L112-R196) [[6]](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64L138-R232) [[7]](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64L160-R271) [[8]](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R285-R298) [[9]](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R321-R341) [[10]](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64L221-R372)