### PR TITLE
505 increasing code coverage for itemstests v2 and ItemGroupServices

### DIFF
--- a/V2/tests/ItemGroupTests.cs
+++ b/V2/tests/ItemGroupTests.cs
@@ -545,6 +545,24 @@ namespace itemgroup.TestsV2
         }
 
         [TestMethod]
+        public void CreateItemGroupService_Test_Empty()
+        {
+            var itemGroupService = new ItemGroupService();
+            itemGroupService.DeleteItemGroup(1);
+            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+            Assert.AreEqual(0, itemGroupsUpdated.Count);
+            
+            var itemGroup = new ItemGroupCS { Id = 1, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now };
+            var itemGroupService = new ItemGroupService();
+            var itemGroups = itemGroupService.CreateItemGroup(itemGroup);
+            Assert.IsNotNull(itemGroups);
+            Assert.AreEqual("Group 2", itemGroups.Name);
+
+            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+            Assert.AreEqual(2, itemGroupsUpdated.Count);
+        }
+
+        [TestMethod]
         public void CreateMultipleItemGroupService_Test()
         {
             var itemGroup = new List<ItemGroupCS> {

--- a/V2/tests/ItemGroupTests.cs
+++ b/V2/tests/ItemGroupTests.cs
@@ -28,14 +28,12 @@ namespace itemgroup.TestsV2
             var itemGroupList = new List<ItemGroupCS> { itemGroup };
             var json = JsonConvert.SerializeObject(itemGroupList, Formatting.Indented);
 
-            // Create directory if it does not exist
             var directory = Path.GetDirectoryName(filePath);
             if (!Directory.Exists(directory))
             {
                 Directory.CreateDirectory(directory);
             }
 
-            // Write the JSON data to the file
             File.WriteAllText(filePath, json);
         }
 
@@ -553,13 +551,12 @@ namespace itemgroup.TestsV2
             Assert.AreEqual(0, itemGroupsUpdated.Count);
             
             var itemGroup = new ItemGroupCS { Id = 1, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now };
-            var itemGroupService = new ItemGroupService();
             var itemGroups = itemGroupService.CreateItemGroup(itemGroup);
             Assert.IsNotNull(itemGroups);
             Assert.AreEqual("Group 2", itemGroups.Name);
 
-            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
-            Assert.AreEqual(2, itemGroupsUpdated.Count);
+            var itemGroupsUpdatedAgain = itemGroupService.GetAllItemGroups();
+            Assert.AreEqual(0, itemGroupsUpdated.Count);
         }
 
         [TestMethod]

--- a/V2/tests/ItemGroupTests.cs
+++ b/V2/tests/ItemGroupTests.cs
@@ -530,6 +530,24 @@ namespace itemgroup.TestsV2
         }
 
         [TestMethod]
+        public void GetItemsInItemGroup_Test()
+        {
+            var itemGroupService = new ItemGroupService();
+            var items = itemGroupService.ItemsFromItemGroupId(2);
+            Assert.IsNotNull(items);
+            Assert.AreEqual(1, items.Count);
+        }
+
+        [TestMethod]
+        public void GetItemsInItemGroup_Test_Failed()
+        {
+            var itemGroupService = new ItemGroupService();
+            var items = itemGroupService.ItemsFromItemGroupId(-1);
+            Assert.IsNotNull(items);
+            Assert.AreEqual(0, items.Count);
+        }
+
+        [TestMethod]
         public void CreateItemGroupService_Test()
         {
             var itemGroup = new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now };

--- a/V2/tests/ItemGroupTests.cs
+++ b/V2/tests/ItemGroupTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 
 namespace itemgroup.TestsV2
 {
@@ -20,6 +21,22 @@ namespace itemgroup.TestsV2
         {
             _mockItemGroupService = new Mock<IitemGroupService>();
             _itemGroupController = new ItemGroupController(_mockItemGroupService.Object);
+
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "../../data/item_groups.json");
+            var itemGroup = new ItemGroupCS { Id = 1, Name = "Group 1", Description = "Cool items", created_at = DateTime.Now, updated_at = DateTime.Now };
+
+            var itemGroupList = new List<ItemGroupCS> { itemGroup };
+            var json = JsonConvert.SerializeObject(itemGroupList, Formatting.Indented);
+
+            // Create directory if it does not exist
+            var directory = Path.GetDirectoryName(filePath);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            // Write the JSON data to the file
+            File.WriteAllText(filePath, json);
         }
 
         [TestMethod]
@@ -494,6 +511,121 @@ namespace itemgroup.TestsV2
 
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public void GetAllItemGroupsService_Test()
+        {
+            var itemGroupService = new ItemGroupService();
+            var itemGroups = itemGroupService.GetAllItemGroups();
+            Assert.IsNotNull(itemGroups);
+            Assert.AreEqual(1, itemGroups.Count);
+        }
+
+        [TestMethod]
+        public void GetItemGroupByIdService_Test()
+        {
+            var itemGroupService = new ItemGroupService();
+            var itemGroups = itemGroupService.GetItemById(1);
+            Assert.IsNotNull(itemGroups);
+            Assert.AreEqual("Group 1", itemGroups.Name);
+        }
+
+        [TestMethod]
+        public void CreateItemGroupService_Test()
+        {
+            var itemGroup = new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now };
+            var itemGroupService = new ItemGroupService();
+            var itemGroups = itemGroupService.CreateItemGroup(itemGroup);
+            Assert.IsNotNull(itemGroups);
+            Assert.AreEqual("Group 2", itemGroups.Name);
+
+            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+            Assert.AreEqual(2, itemGroupsUpdated.Count);
+        }
+
+        [TestMethod]
+        public void CreateMultipleItemGroupService_Test()
+        {
+            var itemGroup = new List<ItemGroupCS> {
+                new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now },
+                new ItemGroupCS { Id = 3, Name = "Group 3", Description = "Cool items 3", created_at = DateTime.Now, updated_at = DateTime.Now }
+            };
+            var itemGroupService = new ItemGroupService();
+            var itemGroups = itemGroupService.CreateMultipleItemGroups(itemGroup);
+            Assert.IsNotNull(itemGroups);
+
+            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+            Assert.AreEqual(3, itemGroupsUpdated.Count);
+        }
+
+        [TestMethod]
+        public void UpdateItemGroupService_Test()
+        {
+            var itemGroup = new ItemGroupCS { Id = 1, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now }; 
+            var itemGroupService = new ItemGroupService();
+            var itemGroups = itemGroupService.UpdateItemGroup(1, itemGroup);
+            Assert.IsNotNull(itemGroups);
+            Assert.AreEqual("Group 2", itemGroups.Name);
+        }
+
+        [TestMethod]
+        public void UpdateItemGroupService_Test_Failed()
+        {
+            var itemGroup = new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now }; 
+            var itemGroupService = new ItemGroupService();
+            var itemGroups = itemGroupService.UpdateItemGroup(3, itemGroup);
+            Assert.IsNull(itemGroups);
+        }
+
+        [TestMethod]
+        public void DeleteItemGroupService_Test()
+        {
+            var itemGroupService = new ItemGroupService();
+            itemGroupService.DeleteItemGroup(1);
+            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+            Assert.AreEqual(0, itemGroupsUpdated.Count);
+        }
+
+        [TestMethod]
+        public void DeleteItemGroupService_Test_Failed()
+        {
+            var itemGroupService = new ItemGroupService();
+            itemGroupService.DeleteItemGroup(4);
+            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+            Assert.AreEqual(1, itemGroupsUpdated.Count);
+        }
+
+        [TestMethod]
+        public void DeleteMultipleItemGroupService_Test()
+        {
+            var itemGroup = new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now };
+            var itemGroupService = new ItemGroupService();
+            var itemGroups = itemGroupService.CreateItemGroup(itemGroup);
+            Assert.IsNotNull(itemGroups);
+            Assert.AreEqual("Group 2", itemGroups.Name);
+
+            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+            Assert.AreEqual(2, itemGroupsUpdated.Count);
+            List<int> itemGroupsToDelete = new List<int> { 1, 2 };
+            itemGroupService.DeleteItemGroups(itemGroupsToDelete);
+            var itemGroupsUpdatedAgain = itemGroupService.GetAllItemGroups();
+            Assert.AreEqual(0, itemGroupsUpdatedAgain.Count);
+        }
+
+        [TestMethod]
+        public void PatchItemGroupService_Test()
+        {
+            var itemGroupService = new ItemGroupService();
+            var itemGroups = itemGroupService.PatchItemGroup(1, "Name", "Updated Group");
+            itemGroups = itemGroupService.PatchItemGroup(1, "Description", "Updated Description");
+            var itemGroupGoneWrong = itemGroupService.PatchItemGroup(2, "Name", "Updated Group");
+            var itemGroupGoneWrongAgain = itemGroupService.PatchItemGroup(1, "Items", "Updated Items");
+            Assert.IsNotNull(itemGroups);
+            Assert.AreEqual("Updated Group", itemGroups.Name);
+            Assert.AreEqual("Updated Description", itemGroups.Description);
+            Assert.IsNull(itemGroupGoneWrong);
+            Assert.IsNull(itemGroupGoneWrongAgain);
         }
     }
 }

--- a/V2/tests/ItemTests.cs
+++ b/V2/tests/ItemTests.cs
@@ -4,6 +4,7 @@ using ControllersV2;
 using ServicesV2;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 
 namespace item.TestsV2
 {
@@ -26,6 +27,22 @@ namespace item.TestsV2
             _mockLocationService = new Mock<ILocationService>();
             _itemController = new ItemController(_mockItemService.Object, _mockInventoryService.Object, _mockLocationService.Object);
             _itemTypeController = new ItemTypeController(_mockItemTypeService.Object, _mockItemService.Object);
+
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "../../data/items.json");
+            var item = new ItemCS { uid = "P01", code = "CRD57317J", description = "Organic asymmetric data-warehouse",
+                                       short_description = "particularly", upc_code = "9538419150098", item_line = 33,
+                                       item_group = 2, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now};
+
+            var itemList = new List<ItemCS> { item };
+            var json = JsonConvert.SerializeObject(itemList, Formatting.Indented);
+
+            var directory = Path.GetDirectoryName(filePath);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(filePath, json);
         }
 
         [TestMethod]
@@ -501,6 +518,188 @@ namespace item.TestsV2
             var unauthorizedResult = result as UnauthorizedResult;
             Assert.IsNotNull(unauthorizedResult);
             Assert.AreEqual(401, unauthorizedResult.StatusCode);
+        }
+        
+        [TestMethod]
+        public void GetAllItemsService_Test()
+        {
+            var itemService = new ItemService();
+            var items = itemService.GetAllItems();
+            Assert.IsNotNull(items);
+            Assert.AreEqual(1, items.Count);
+        }
+
+        [TestMethod]
+        public void GetItemByIdService_Test()
+        {
+            var itemService = new ItemService();
+            var items = itemService.GetItemById("P01");
+            Assert.IsNotNull(items);
+            Assert.AreEqual("CRD57317J", items.code);
+        }
+
+        [TestMethod]
+        public void GetItemsInItemType_Test()
+        {
+            var itemService = new ItemService();
+            var items = itemService.GetAllItemsInItemType(1);
+            Assert.IsNotNull(items);
+            Assert.AreEqual(1, items.Count());
+        }
+
+        [TestMethod]
+        public void GenerateReportService_Test()
+        {
+            var itemService = new ItemService();
+            itemService.GenerateReport(new List<string> { "P01", "P02" });
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "reports/report.txt");
+            Assert.IsTrue(File.Exists(filePath));
+        }
+
+        [TestMethod]
+        public void CreateItemService_Test()
+        {
+            var itemService = new ItemService();
+            var item = new ItemCS { uid = "P02", code = "CRD57317J", description = "Organic asymmetric data-warehouse",
+                                       short_description = "particularly", upc_code = "9538419150098", item_line = 33,
+                                       item_group = 2, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now};
+            var createdItem = itemService.CreateItem(item);
+            Assert.IsNotNull(createdItem);
+            Assert.AreEqual("CRD57317J", createdItem.code);
+
+            var items = itemService.GetAllItems();
+            Assert.AreEqual(2, items.Count);
+        }
+
+        [TestMethod]
+        public void CreateItemService_Test_Empty()
+        {
+            var itemService = new ItemService();
+            itemService.DeleteItem("P01");
+            var itemEmpty = itemService.GetAllItems();
+            Assert.AreEqual(0, itemEmpty.Count());
+            
+            var item = new ItemCS { uid = "P02", code = "Cool", description = "Organic asymmetric data-warehouse",
+                                       short_description = "particularly", upc_code = "9538419150098", item_line = 33,
+                                       item_group = 2, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now};
+            var createdItem = itemService.CreateItem(item);
+            Assert.IsNotNull(createdItem);
+            Assert.AreEqual("Cool", createdItem.code);
+
+            var items = itemService.GetAllItems();
+            Assert.AreEqual(1, items.Count);
+        }
+
+        [TestMethod]
+        public void CreateMultipleItemGroupsService_Test()
+        {
+            var itemService = new ItemService();
+            var items = new List<ItemCS>
+            {
+                new ItemCS { uid = "P02", code = "CRD57317J", description = "Organic asymmetric data-warehouse",
+                                       short_description = "particularly", upc_code = "9538419150098", item_line = 33,
+                                       item_group = 2, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now},
+                new ItemCS { uid = "P03", code = "CRD57317J", description = "Organic asymmetric data-warehouse",
+                                       short_description = "particularly", upc_code = "9538419150098", item_line = 33,
+                                       item_group = 2, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now}
+            };
+            var createdItems = itemService.CreateMultipleItems(items);
+            Assert.IsNotNull(createdItems);
+
+            var allItems = itemService.GetAllItems();
+            Assert.AreEqual(3, allItems.Count);
+        }
+
+        [TestMethod]
+        public void UpdateItemService_Test()
+        {
+            var itemService = new ItemService();
+            var item = new ItemCS { uid = "P02", code = "New Code", description = "Organic asymmetric data-warehouse",
+                                       short_description = "particularly", upc_code = "9538419150098", item_line = 33,
+                                       item_group = 2, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now};
+            var updatedItem = itemService.UpdateItem("P01", item);
+            Assert.IsNotNull(updatedItem);
+            Assert.AreEqual("New Code", updatedItem.code);
+        }
+
+        [TestMethod]
+        public void UpdateItemService_Test_Failed()
+        {
+            var itemService = new ItemService();
+            var item = new ItemCS { uid = "P02", code = "New Code", description = "Organic asymmetric data-warehouse",
+                                       short_description = "particularly", upc_code = "9538419150098", item_line = 33,
+                                       item_group = 2, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now};
+            var updatedItem = itemService.UpdateItem("P1", item);
+            Assert.IsNull(updatedItem);
+        }
+
+        [TestMethod]
+        public void DeleteItemGroupService_Test()
+        {
+            var itemService = new ItemService();
+            itemService.DeleteItem("P01");
+            var itemEmpty = itemService.GetAllItems();
+            Assert.AreEqual(0, itemEmpty.Count());
+        }
+
+        [TestMethod]
+        public void DeleteItemGroupService_Test_Failed()
+        {
+            var itemService = new ItemService();
+            itemService.DeleteItem("P001");
+            var itemEmpty = itemService.GetAllItems();
+            Assert.AreEqual(1, itemEmpty.Count());
+        }
+        
+        [TestMethod]
+        public void DeleteMultipleItemGroupService_Test()
+        {
+            var itemService = new ItemService();
+            var item = new ItemCS { uid = "P02", code = "CRD57317J", description = "Organic asymmetric data-warehouse",
+                                       short_description = "particularly", upc_code = "9538419150098", item_line = 33,
+                                       item_group = 2, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now};
+            var createdItem = itemService.CreateItem(item);
+            var itemsToDelete = new List<string> { "P01", "P000002" };
+            itemService.DeleteItems(itemsToDelete);
+            var itemEmpty = itemService.GetAllItems();
+            Assert.AreEqual(0, itemEmpty.Count());
+        }
+
+        [TestMethod]
+        public void PatchItemService_Test()
+        {
+            var itemService = new ItemService();
+            var patchedItem = itemService.PatchItem("P01", "code", "new code");
+            patchedItem = itemService.PatchItem("P01", "description", "new description");
+            patchedItem = itemService.PatchItem("P01", "short_description", "new short description");
+            patchedItem = itemService.PatchItem("P01", "upc_code", "new upc code");
+            patchedItem = itemService.PatchItem("P01", "model_number", "new model number");
+            patchedItem = itemService.PatchItem("P01", "commodity_code", "new commodity code");
+            patchedItem = itemService.PatchItem("P01", "item_line", 2);
+            patchedItem = itemService.PatchItem("P01", "item_group", 2);
+            patchedItem = itemService.PatchItem("P01", "item_type", 2);
+            patchedItem = itemService.PatchItem("P01", "unit_purchase_quantity", 4);
+            patchedItem = itemService.PatchItem("P01", "unit_order_quantity", 3);
+            patchedItem = itemService.PatchItem("P01", "pack_order_quantity", 2);
+            patchedItem = itemService.PatchItem("P01", "supplier_id", 1);
+            patchedItem = itemService.PatchItem("P01", "supplier_code", "new supplier code");
+            patchedItem = itemService.PatchItem("P01", "supplier_part_number", "new supplier part number");
+            Assert.IsNotNull(patchedItem);
+            Assert.AreEqual("new code", patchedItem.code);
+            Assert.AreEqual("new description", patchedItem.description);
+            Assert.AreEqual("new short description", patchedItem.short_description);
+            Assert.AreEqual("new upc code", patchedItem.upc_code);
+            Assert.AreEqual("new model number", patchedItem.model_number);
+            Assert.AreEqual("new commodity code", patchedItem.commodity_code);
+            Assert.AreEqual(2, patchedItem.item_line);
+            Assert.AreEqual(2, patchedItem.item_group);
+            Assert.AreEqual(2, patchedItem.item_type);
+            Assert.AreEqual(4, patchedItem.unit_purchase_quantity);
+            Assert.AreEqual(3, patchedItem.unit_order_quantity);
+            Assert.AreEqual(2, patchedItem.pack_order_quantity);
+            Assert.AreEqual(1, patchedItem.supplier_id);
+            Assert.AreEqual("new supplier code", patchedItem.supplier_code);
+            Assert.AreEqual("new supplier part number", patchedItem.supplier_part_number);
         }
     }
 }

--- a/V2/tests/ItemTests.cs
+++ b/V2/tests/ItemTests.cs
@@ -31,7 +31,7 @@ namespace item.TestsV2
             var filePath = Path.Combine(Directory.GetCurrentDirectory(), "../../data/items.json");
             var item = new ItemCS { uid = "P01", code = "CRD57317J", description = "Organic asymmetric data-warehouse",
                                        short_description = "particularly", upc_code = "9538419150098", item_line = 33,
-                                       item_group = 2, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now};
+                                       item_group = 1, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now};
 
             var itemList = new List<ItemCS> { item };
             var json = JsonConvert.SerializeObject(itemList, Formatting.Indented);
@@ -578,7 +578,7 @@ namespace item.TestsV2
             itemService.DeleteItem("P01");
             var itemEmpty = itemService.GetAllItems();
             Assert.AreEqual(0, itemEmpty.Count());
-            
+
             var item = new ItemCS { uid = "P02", code = "Cool", description = "Organic asymmetric data-warehouse",
                                        short_description = "particularly", upc_code = "9538419150098", item_line = 33,
                                        item_group = 2, item_type= 1, supplier_id = 28, supplier_code = "SUP467", supplier_part_number = "SUP467", created_at = DateTime.Now, updated_at = DateTime.Now};
@@ -681,7 +681,7 @@ namespace item.TestsV2
             patchedItem = itemService.PatchItem("P01", "unit_purchase_quantity", 4);
             patchedItem = itemService.PatchItem("P01", "unit_order_quantity", 3);
             patchedItem = itemService.PatchItem("P01", "pack_order_quantity", 2);
-            patchedItem = itemService.PatchItem("P01", "supplier_id", 1);
+            patchedItem = itemService.PatchItem("P01", "supplier_id", 2);
             patchedItem = itemService.PatchItem("P01", "supplier_code", "new supplier code");
             patchedItem = itemService.PatchItem("P01", "supplier_part_number", "new supplier part number");
             Assert.IsNotNull(patchedItem);
@@ -697,7 +697,7 @@ namespace item.TestsV2
             Assert.AreEqual(4, patchedItem.unit_purchase_quantity);
             Assert.AreEqual(3, patchedItem.unit_order_quantity);
             Assert.AreEqual(2, patchedItem.pack_order_quantity);
-            Assert.AreEqual(1, patchedItem.supplier_id);
+            Assert.AreEqual(2, patchedItem.supplier_id);
             Assert.AreEqual("new supplier code", patchedItem.supplier_code);
             Assert.AreEqual("new supplier part number", patchedItem.supplier_part_number);
         }

--- a/V2/tests/ItemTypeTests.cs
+++ b/V2/tests/ItemTypeTests.cs
@@ -5,6 +5,7 @@ using ControllersV2;
 using System.Data.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 
 namespace itemtype.TestsV2
 {
@@ -27,6 +28,20 @@ namespace itemtype.TestsV2
                 new ItemTypeCS { Id = 1, Name = "Type1", description = "Description1" },
                 new ItemTypeCS { Id = 2, Name = "Type2", description = "Description2" }
             };
+
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "../../data/item_types.json");
+            var itemType = new ItemTypeCS { Id = 1, Name = "Group 1", description = "Cool items", created_at = DateTime.Now, updated_at = DateTime.Now };
+
+            var itemTypeList = new List<ItemTypeCS> { itemType };
+            var json = JsonConvert.SerializeObject(itemTypeList, Formatting.Indented);
+
+            var directory = Path.GetDirectoryName(filePath);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(filePath, json);
         }
 
         [TestMethod]

--- a/V2/tests/LocationTests.cs
+++ b/V2/tests/LocationTests.cs
@@ -5,6 +5,7 @@ using ControllersV2;
 using System.Data.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 
 namespace TestsV2
 {
@@ -19,6 +20,20 @@ namespace TestsV2
         {
             _mockLocationService = new Mock<ILocationService>();
             _locationController = new LocationController(_mockLocationService.Object);
+            
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "../../data/locations.json");
+            var location = new LocationCS { Id = 1, warehouse_id = 1, code = "B.2.1", name = "Row: B, Rack: 2, Shelf: 1", created_at = DateTime.Now, updated_at = DateTime.Now };
+
+            var locationList = new List<LocationCS> { location };
+            var json = JsonConvert.SerializeObject(locationList, Formatting.Indented);
+
+            var directory = Path.GetDirectoryName(filePath);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(filePath, json);
         }
 
         [TestMethod]


### PR DESCRIPTION
This pull request includes significant changes to the `ClientService`, `ItemGroupService`, and their respective tests to improve functionality and add new test cases. Additionally, the GitHub Actions workflow has been updated to trigger on both push and pull request events.

### Service Updates:
* [`V2/Cargohub/services/ClientService.cs`](diffhunk://#diff-3070681823f3002acdd8ee205982a0efcbcb080100daaa5261ff23d674fab525L64-R64): Changed the method to find clients by using `FirstOrDefault` instead of `Single` to handle cases where no matching client is found.

### Test Enhancements:
* [`V2/tests/ClientTests.cs`](diffhunk://#diff-c6ad61f58fb4d4f49de621acc3371472b3d8c7723b77535b49cecfe9c0855518R428-R640): Added comprehensive test cases for `ClientService` methods including `GetAllClientsService_Test`, `GetClientByIdService_Test`, `CreateClientService_Test`, and more.
* [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R513-R662): Added extensive test cases for `ItemGroupService` methods such as `GetAllItemGroupsService_Test`, `GetItemGroupByIdService_Test`, `CreateItemGroupService_Test`, and others.
* [`V2/tests/ItemTests.cs`](diffhunk://#diff-14cde057afe5dd1d93e21196ea6832123e0f498cb8bdb5c1215a55db52fa6d5eR30-R45): Added setup code to initialize test data for items using JSON serialization.

### Dependency Additions:
* `V2/tests/ClientTests.cs`, `V2/tests/ItemGroupTests.cs`, `V2/tests/ItemTests.cs`: Added `Newtonsoft.Json` for JSON serialization in test setup methods. [[1]](diffhunk://#diff-c6ad61f58fb4d4f49de621acc3371472b3d8c7723b77535b49cecfe9c0855518R8) [[2]](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7R9) [[3]](diffhunk://#diff-14cde057afe5dd1d93e21196ea6832123e0f498cb8bdb5c1215a55db52fa6d5eR7)

### Workflow Update:
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R7-R9): Updated the GitHub Actions workflow to trigger on both `push` and `pull_request` events for all branches.