### PR TITLE
508 increasing code coverage on itemlineservice v2

### DIFF
--- a/V2/tests/ItemGroupTests.cs
+++ b/V2/tests/ItemGroupTests.cs
@@ -574,7 +574,7 @@ namespace itemgroup.TestsV2
             Assert.AreEqual("Group 2", itemGroups.Name);
 
             var itemGroupsUpdatedAgain = itemGroupService.GetAllItemGroups();
-            Assert.AreEqual(0, itemGroupsUpdated.Count);
+            Assert.AreEqual(1, itemGroupsUpdatedAgain.Count);
         }
 
         [TestMethod]

--- a/V2/tests/ItemTests.cs
+++ b/V2/tests/ItemTests.cs
@@ -684,7 +684,9 @@ namespace item.TestsV2
             patchedItem = itemService.PatchItem("P01", "supplier_id", 2);
             patchedItem = itemService.PatchItem("P01", "supplier_code", "new supplier code");
             patchedItem = itemService.PatchItem("P01", "supplier_part_number", "new supplier part number");
+            var patchedItemGoneWrong = itemService.PatchItem("-1", "supplier_part_number", "new supplier part number");
             Assert.IsNotNull(patchedItem);
+            Assert.IsNull(patchedItemGoneWrong);
             Assert.AreEqual("new code", patchedItem.code);
             Assert.AreEqual("new description", patchedItem.description);
             Assert.AreEqual("new short description", patchedItem.short_description);


### PR DESCRIPTION
This pull request includes several changes to the test files in the `V2/tests` directory. The most significant changes involve adding new test methods for the `ItemLineService` and updating existing assertions. Additionally, a new dependency was added to the `ItemLineTests.cs` file.

**Test Enhancements:**

* [`V2/tests/ItemLineTests.cs`](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R585-R726): Added multiple new test methods for `ItemLineService`, including tests for creating, updating, deleting, and patching item lines. These methods ensure comprehensive coverage of the service's functionality.

* [`V2/tests/ItemLineTests.cs`](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R24-R37): Updated the `Setup` method to include the creation of a sample JSON file with item line data for testing purposes. This setup helps to simulate a real-world scenario for the tests.

**Dependency Updates:**

* [`V2/tests/ItemLineTests.cs`](diffhunk://#diff-08e3c5ab9a57bf514b8e5ccaaca1538c5795c58d86ae4d8aa53fbefa326aca92R9): Added `Newtonsoft.Json` as a new dependency to handle JSON serialization and deserialization in the test setup.

**Assertion Fixes:**

* [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7L577-R577): Corrected an assertion in the `CreateItemGroupService_Test_Empty` method to check for the correct count of item groups after an update.

* [`V2/tests/ItemTests.cs`](diffhunk://#diff-14cde057afe5dd1d93e21196ea6832123e0f498cb8bdb5c1215a55db52fa6d5eR687-R689): Added assertions to check for null values when patching an item with incorrect data in the `PatchItemService_Test` method.