### PR TITLE
inventoriestest v1 done

### DIFF
--- a/V1/tests/InventoryTests.cs
+++ b/V1/tests/InventoryTests.cs
@@ -5,6 +5,8 @@ using ControllersV1;
 using System.Data.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Newtonsoft.Json;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace TestsV1
 {
@@ -19,9 +21,130 @@ namespace TestsV1
         {
             _mockInventoryService = new Mock<IInventoryService>();
             _inventoryController = new InventoryController(_mockInventoryService.Object);
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "../../data/inventories.json");
+            var inventory = new InventoryCS(){
+                Id= 1,
+                item_id= "P000001",
+                description="Face-to-face clear-thinking complexity",
+                item_reference="sjQ23408K",
+                Locations= new List<int>(){
+                    3211,
+                    24700,
+                    14123,
+                    19538,
+                    31071,
+                    24701,
+                    11606,
+                    11817
+                    },
+                total_on_hand=262,
+                total_expected=0,
+                total_ordered=80,
+                total_allocated=41,
+                total_available=141,
+                created_at=DateTime.Now,
+                updated_at=DateTime.Now,
+            };
+            var inventorieslist = new List<InventoryCS>(){ inventory };
+            var json = JsonConvert.SerializeObject(inventorieslist);
+            var directory = Path.GetDirectoryName(filePath);
+            if(!Directory.Exists(directory)){
+                Directory.CreateDirectory(directory);
+            }
+            File.WriteAllText(filePath, json);
         }
-
         [TestMethod]
+        public void GetAllInventoriesService_Test_Succes(){
+            var inventoryservice = new InventoryService();
+            var result = inventoryservice.GetAllInventories();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Count);
+        }
+        [TestMethod]
+        public void GetInventoryById_Test_Succes(){
+            var inventoryservice = new InventoryService();
+            var result = inventoryservice.GetInventoryById(1);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("P000001", result.item_id);
+        }
+        [TestMethod]
+        public void GetInventoriesForItem_Test_Succes(){
+            var inventoryservice = new InventoryService();
+            var result = inventoryservice.GetInventoriesForItem("P000001");
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Id);
+        }
+        [TestMethod]
+        public void CreateInventory_Test_Succes(){
+            var inventory = new InventoryCS(){
+                Id= 2,
+                item_id= "P000002",
+                description="Focused transitional alliance",
+                item_reference="nyg48736S",
+                Locations=new List<int>{
+                    19800,
+                    23653,
+                    3068,
+                    3334,
+                    20477,
+                    20524,
+                    17579,
+                    2271,
+                    2293,
+                    22717
+                    },
+                total_on_hand=194,
+                total_expected=0,
+                total_ordered=139,
+                total_allocated=0,
+                total_available=55,
+                created_at=DateTime.Now,
+                updated_at=DateTime.Now
+                };
+                var inventoryservice = new InventoryService();
+                var result = inventoryservice.CreateInventory(inventory);
+                var updatedinventories = inventoryservice.GetAllInventories();
+                Assert.IsNotNull(result);
+                Assert.AreEqual(2, updatedinventories.Count);
+                Assert.AreEqual("P000002", updatedinventories[1].item_id);
+        }
+        [TestMethod]
+        public void UpdateInventoryById_Test_Succes(){
+            var updatedinventory = new InventoryCS(){
+                Id= 1,
+                item_id= "P000001",
+                description="updated test",
+                item_reference="sjQ23408K",
+                Locations= new List<int>(){
+                    3211,
+                    24700,
+                    14123,
+                    19538,
+                    31071,
+                    24701,
+                    11606,
+                    11817
+                    },
+                total_on_hand=262,
+                total_expected=0,
+                total_ordered=80,
+                total_allocated=41,
+                total_available=141,
+                created_at=DateTime.Now,
+                updated_at=DateTime.Now,
+            };
+            var inventoryservice = new InventoryService();
+            var result = inventoryservice.UpdateInventoryById(1, updatedinventory);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("updated test", result.description);
+        }
+        [TestMethod]
+        public void DeleteInventoryService_Test_Succes(){
+            var inventoryservice = new InventoryService();
+            inventoryservice.DeleteInventory(1);
+            var updatedinventories = inventoryservice.GetAllInventories();
+            Assert.AreEqual(0, updatedinventories.Count);
+        }
         public void GetInventoriesTest_Exists()
         {
             //arrange


### PR DESCRIPTION
This pull request includes significant changes to the `V1/tests/InventoryTests.cs` file, mainly focusing on enhancing the test coverage for the inventory service. The changes involve adding new test methods, creating mock data for testing, and ensuring proper setup for the tests.

Enhancements to test coverage:

* Added necessary imports for JSON handling and test platform object model. (`V1/tests/InventoryTests.cs`)
* Created mock inventory data and wrote it to a JSON file during the setup phase to facilitate testing. (`V1/tests/InventoryTests.cs`)

New test methods:

* Added `GetAllInventoriesService_Test_Succes` to test the retrieval of all inventories. (`V1/tests/InventoryTests.cs`)
* Added `GetInventoryById_Test_Succes` to test the retrieval of an inventory by its ID. (`V1/tests/InventoryTests.cs`)
* Added `GetInventoriesForItem_Test_Succes` to test the retrieval of inventories for a specific item. (`V1/tests/InventoryTests.cs`)
* Added `CreateInventory_Test_Succes` to test the creation of a new inventory. (`V1/tests/InventoryTests.cs`)
* Added `UpdateInventoryById_Test_Succes` to test updating an inventory by its ID. (`V1/tests/InventoryTests.cs`)
* Added `DeleteInventoryService_Test_Succes` to test the deletion of an inventory. (`V1/tests/InventoryTests.cs`)