### PR TITLE
524 code coverage suppliers v2

### DIFF
--- a/V2/Cargohub/services/SupplierService.cs
+++ b/V2/Cargohub/services/SupplierService.cs
@@ -59,7 +59,7 @@ public class SupplierService : ISupplierService
     public SupplierCS UpdateSupplier(int id, SupplierCS updateSupplier)
     {
         var allSuppliers = GetAllSuppliers();
-        var supplierToUpdate = allSuppliers.Single(supplier => supplier.Id == id);
+        var supplierToUpdate = allSuppliers.SingleOrDefault(supplier => supplier.Id == id);
 
         if (supplierToUpdate is not null)
         {

--- a/V2/tests/SupplierTests.cs
+++ b/V2/tests/SupplierTests.cs
@@ -671,6 +671,269 @@ namespace TestsV2
             Assert.IsNotNull(suppliers);
             Assert.AreEqual(1, suppliers.Count);
         }
+
+        [TestMethod]
+        public void GetSupplierByIdService_Test(){
+
+            var supplierService = new SupplierService();
+            var supplier = supplierService.GetSupplierById(1);
+            Assert.IsNotNull(supplier);
+            Assert.AreEqual("Lee, Parks and Johnson", supplier.Name);
+        }
+
+        [TestMethod]
+        public void CreateSupplierService_Test(){
+
+            var supplierService = new SupplierService();
+            var supplier = new SupplierCS
+            {
+                Id = 2,
+                Code = "SUP0002",
+                Name = "Daniel Inc",
+                Address = "1296 Daniel Road Apt. 349",
+                address_extra = "Apt. 349",
+                City = "Pierceview",
+                zip_code = "28301",
+                Province = "Colorado",
+                Country = "United States",
+                contact_name = "Bryan Clark",
+                PhoneNumber = "242.732.3483x2573x2573",
+                Reference = "DInc-SUP0002",
+                created_at = DateTime.Now,
+                updated_at = DateTime.Now
+            };
+            var suppliers = supplierService.CreateSupplier(supplier);
+            Assert.IsNotNull(suppliers);
+            Assert.AreEqual("Daniel Inc", suppliers.Name);
+
+            var suppliersUpdated = supplierService.GetAllSuppliers();
+            Assert.AreEqual(2, suppliersUpdated.Count);
+        }
+
+        [TestMethod]
+        public void CreateMultipleSuppliersService_Test(){
+            var supplierService = new SupplierService();
+            var suppliers = new List<SupplierCS>
+            {
+                new SupplierCS
+                {
+                    Id = 3,
+                    Code = "SUP0003",
+                    Name = "Daniel Inc",
+                    Address = "1296 Daniel Road Apt. 349",
+                    address_extra = "Apt. 349",
+                    City = "Pierceview",
+                    zip_code = "28301",
+                    Province = "Colorado",
+                    Country = "United States",
+                    contact_name = "Bryan Clark",
+                    PhoneNumber = "242.732.3483x2573x2573",
+                    Reference = "DInc-SUP0003",
+                    created_at = DateTime.Now,
+                    updated_at = DateTime.Now
+                },
+                new SupplierCS
+                {
+                    Id = 4,
+                    Code = "SUP0004",
+                    Name = "Daniel Inc",
+                    Address = "1296 Daniel Road Apt. 349",
+                    address_extra = "Apt. 349",
+                    City = "Pierceview",
+                    zip_code = "28301",
+                    Province = "Colorado",
+                    Country = "United States",
+                    contact_name = "Bryan Clark",
+                    PhoneNumber = "242.732.3483x2573x2573",
+                    Reference = "DInc-SUP0004",
+                    created_at = DateTime.Now,
+                    updated_at = DateTime.Now
+                }
+            };
+            var suppliersAdded = supplierService.CreateMultipleSuppliers(suppliers);
+            Assert.IsNotNull(suppliersAdded);
+            Assert.AreEqual(2, suppliersAdded.Count);
+
+            var suppliersUpdated = supplierService.GetAllSuppliers();
+            Assert.AreEqual(3, suppliersUpdated.Count);
+        }
+
+        [TestMethod]
+        public void UpdateSupplierService_Test(){
+            var supplierService = new SupplierService();
+            var supplier = new SupplierCS
+            {
+                Id = 1,
+                Code = "SUP0001",
+                Name = "Lee, Par",
+                Address = "5989 Sullivan Drives",
+                address_extra = "Apt. 996",
+                City = "Port Anitaburgh",
+                zip_code = "91688",
+                Province = "Illinois",
+                Country = "Czech Republic",
+                contact_name = "Toni Barnett",
+                PhoneNumber = "363.541.7282x36825",
+                Reference = "LPaJ-SUP0001",
+                created_at = DateTime.Now,
+                updated_at = DateTime.Now
+            };
+            var supplierUpdated = supplierService.UpdateSupplier(1, supplier);
+            Assert.IsNotNull(supplierUpdated);
+            Assert.AreEqual("Lee, Par", supplierUpdated.Name);
+        }
+
+        [TestMethod]
+        public void UpdateSupplierService_FailTest(){
+            var supplierService = new SupplierService();
+            var supplier = new SupplierCS
+            {
+                Id = 1,
+                Code = "SUP0001",
+                Name = "Lee, Par",
+                Address = "5989 Sullivan Drives",
+                address_extra = "Apt. 996",
+                City = "Port Anitaburgh",
+                zip_code = "91688",
+                Province = "Illinois",
+                Country = "Czech Republic",
+                contact_name = "Toni Barnett",
+                PhoneNumber = "363.541.7282x36825",
+                Reference = "LPaJ-SUP0001",
+                created_at = DateTime.Now,
+                updated_at = DateTime.Now
+            };
+            var supplierUpdated = supplierService.UpdateSupplier(2, supplier);
+            Assert.IsNull(supplierUpdated);
+        }  
+
+        [TestMethod]
+        public void DeleteSupplierService_Test(){
+            var supplierService = new SupplierService();
+            supplierService.DeleteSupplier(1);
+            var suppliers = supplierService.GetAllSuppliers();
+            Assert.AreEqual(0, suppliers.Count);
+        }
+
+        [TestMethod]
+        public void DeleteSupplierService_FailTest(){
+            var supplierService = new SupplierService();
+            supplierService.DeleteSupplier(2);
+            var suppliers = supplierService.GetAllSuppliers();
+            Assert.AreEqual(1, suppliers.Count);
+        } 
+
+        [TestMethod]
+        public void GetItemsBySupplierIdService_Test(){
+            var supplierService = new SupplierService();
+            var items = supplierService.GetItemsBySupplierId(1);
+            Assert.IsNotNull(items);
+            Assert.AreEqual(0, items.Count);
+        }
+
+        [TestMethod]
+        public void PatchSupplierService_Test(){
+            //  var clientService = new ClientService();
+            // var clients = clientService.PatchClient(1, "name", "new name");
+            // clients = clientService.PatchClient(1, "address", "new address");
+            // clients = clientService.PatchClient(1, "city", "new city");
+            // clients = clientService.PatchClient(1, "zip_code", "new zip_code");
+            // clients = clientService.PatchClient(1, "province", "new Province");
+            // clients = clientService.PatchClient(1, "country", "new Country");
+            // clients = clientService.PatchClient(1, "contact_name", "new contact_name");
+            // clients = clientService.PatchClient(1, "contact_phone", "new contact_phone");
+            // clients = clientService.PatchClient(1, "contact_email", "new contact_email");
+            // Assert.IsNotNull(clients);
+            // Assert.AreEqual("new name", clients.Name);
+            // Assert.AreEqual("new address", clients.Address);
+            // Assert.AreEqual("new city", clients.City);
+            // Assert.AreEqual("new zip_code", clients.zip_code);
+            // Assert.AreEqual("new Province", clients.Province);
+            // Assert.AreEqual("new Country", clients.Country);
+            // Assert.AreEqual("new contact_name", clients.contact_name);
+            // Assert.AreEqual("new contact_phone", clients.contact_phone);
+            // Assert.AreEqual("new contact_email", clients.contact_email);
+
+            var supplierService = new SupplierService();
+            var suppliers = supplierService.PatchSupplier(1, "Name", "New Name");
+            suppliers = supplierService.PatchSupplier(1, "Code", "New Code");
+            suppliers = supplierService.PatchSupplier(1, "Address", "New Address");
+            suppliers = supplierService.PatchSupplier(1, "address_extra", "New Address Extra");
+            suppliers = supplierService.PatchSupplier(1, "City", "New City");
+            suppliers = supplierService.PatchSupplier(1, "zip_code", "New Zip Code");
+            suppliers = supplierService.PatchSupplier(1, "Province", "New Province");
+            suppliers = supplierService.PatchSupplier(1, "Country", "New Country");
+            suppliers = supplierService.PatchSupplier(1, "contact_name", "New Contact Name");
+            suppliers = supplierService.PatchSupplier(1, "PhoneNumber", "New Phone Number");
+            suppliers = supplierService.PatchSupplier(1, "Reference", "New Reference");
+            Assert.IsNotNull(suppliers);
+            Assert.AreEqual("New Name", suppliers.Name);
+            Assert.AreEqual("New Code", suppliers.Code);
+            Assert.AreEqual("New Address", suppliers.Address);
+            Assert.AreEqual("New Address Extra", suppliers.address_extra);
+            Assert.AreEqual("New City", suppliers.City);
+            Assert.AreEqual("New Zip Code", suppliers.zip_code);
+            Assert.AreEqual("New Province", suppliers.Province);
+            Assert.AreEqual("New Country", suppliers.Country);
+            Assert.AreEqual("New Contact Name", suppliers.contact_name);
+            Assert.AreEqual("New Phone Number", suppliers.PhoneNumber);
+            Assert.AreEqual("New Reference", suppliers.Reference);
+        }
+
+        [TestMethod]
+        public void PatchSupplierService_FailTest(){
+            var supplierService = new SupplierService();
+            var suppliers = supplierService.PatchSupplier(2, "Name", "New Name");
+            Assert.IsNull(suppliers);
+        }
+
+        [TestMethod]
+        public void DeleteSuppliersService_Test(){
+            //create and add a list first to delete
+            var suppliers = new List<SupplierCS>
+            {
+                new SupplierCS
+                {
+                    Id = 2,
+                    Code = "SUP0002",
+                    Name = "Daniel Inc",
+                    Address = "1296 Daniel Road Apt. 349",
+                    address_extra = "Apt. 349",
+                    City = "Pierceview",
+                    zip_code = "28301",
+                    Province = "Colorado",
+                    Country = "United States",
+                    contact_name = "Bryan Clark",
+                    PhoneNumber = "242.732.3483x2573x2573",
+                    Reference = "DInc-SUP0002",
+                    created_at = DateTime.Now,
+                    updated_at = DateTime.Now
+                },
+                new SupplierCS
+                {
+                    Id = 3,
+                    Code = "SUP0003",
+                    Name = "Another Supplier",
+                    Address = "1234 Another St",
+                    address_extra = "Suite 100",
+                    City = "Another City",
+                    zip_code = "12345",
+                    Province = "Another Province",
+                    Country = "Another Country",
+                    contact_name = "Another Contact",
+                    PhoneNumber = "123-456-7890",
+                    Reference = "ASUP-SUP0003",
+                    created_at = DateTime.Now,
+                    updated_at = DateTime.Now
+                }
+            };
+            var supplierService = new SupplierService();
+            supplierService.CreateMultipleSuppliers(suppliers);
+            var suppliersToDelete = new List<int>() { 1, 2, 3 };
+            supplierService.DeleteSuppliers(suppliersToDelete);
+            var totalSuppliers = supplierService.GetAllSuppliers();
+            Assert.AreEqual(0, totalSuppliers.Count);
+        }
     }
 }
 

--- a/V2/tests/SupplierTests.cs
+++ b/V2/tests/SupplierTests.cs
@@ -5,6 +5,7 @@ using ControllersV2;
 using System.Data.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 
 namespace TestsV2
 {
@@ -19,7 +20,39 @@ namespace TestsV2
         {
             _mockSupplierService = new Mock<ISupplierService>();
             _supplierController = new SupplierController(_mockSupplierService.Object);
+
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "../../data/suppliers.json");
+            var supplier = new SupplierCS { 
+                Id = 1,
+                Code = "SUP0001",
+                Name = "Lee, Parks and Johnson",
+                Address = "5989 Sullivan Drives",
+                address_extra = "Apt. 996",
+                City = "Port Anitaburgh",
+                zip_code = "91688",
+                Province = "Illinois",
+                Country = "Czech Republic",
+                contact_name = "Toni Barnett",
+                PhoneNumber = "363.541.7282x36825",
+                Reference = "LPaJ-SUP0001",
+                created_at = DateTime.Now,
+                updated_at = DateTime.Now
+                };
+
+            var supplierlist = new List<SupplierCS> { supplier };
+            var json = JsonConvert.SerializeObject(supplierlist, Formatting.Indented);
+
+            // Create directory if it does not exist
+            var directory = Path.GetDirectoryName(filePath);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            // Write the JSON data to the file
+            File.WriteAllText(filePath, json);
         }
+        
 
         [TestMethod]
         public void GetSuppliersTest_Exists()
@@ -628,6 +661,17 @@ namespace TestsV2
             Assert.IsNotNull(unauthorizedResult);
             Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
+
+        // Test for the services
+        [TestMethod]
+        public void GetAllSuppliersService_Test(){
+
+            var supplierService = new SupplierService();
+            var suppliers = supplierService.GetAllSuppliers();
+            Assert.IsNotNull(suppliers);
+            Assert.AreEqual(1, suppliers.Count);
+        }
     }
 }
+
 

--- a/V2/tests/TransferTests.cs
+++ b/V2/tests/TransferTests.cs
@@ -746,7 +746,7 @@ namespace TestsV2
             var result = transferService.UpdateTransfer(5, transfer);
             Assert.IsNull(result);
         }
-
+// CHECK THIS NEXT TEST
         [TestMethod]
         public void CommitTransferService_Test()
         {


### PR DESCRIPTION
This pull request includes several changes to the `SupplierService` and its corresponding tests in the `SupplierTests` file. The most important changes include updating the method for fetching a supplier by ID, adding new test methods for various supplier services, and initializing test data for suppliers.

Updates to `SupplierService`:

* [`V2/Cargohub/services/SupplierService.cs`](diffhunk://#diff-133e2935af7375fbe2079721d1770a296906f335b69d20fec274c1791f5c71bcL62-R62): Changed `Single` to `SingleOrDefault` in the `UpdateSupplier` method to handle cases where no supplier is found.

Enhancements to `SupplierTests`:

* [`V2/tests/SupplierTests.cs`](diffhunk://#diff-3d93140d6bdf8d2b2b6571ec6542ca906884c46966479b65948ec6089eeea7bfR8): Added `Newtonsoft.Json` to handle JSON serialization for test data.
* [`V2/tests/SupplierTests.cs`](diffhunk://#diff-3d93140d6bdf8d2b2b6571ec6542ca906884c46966479b65948ec6089eeea7bfR23-R56): Initialized supplier test data in the `Setup` method by writing a JSON file with supplier details.
* [`V2/tests/SupplierTests.cs`](diffhunk://#diff-3d93140d6bdf8d2b2b6571ec6542ca906884c46966479b65948ec6089eeea7bfR664-R940): Added multiple new test methods to cover various functionalities of the `SupplierService`, including `GetAllSuppliersService_Test`, `GetSupplierByIdService_Test`, `CreateSupplierService_Test`, `CreateMultipleSuppliersService_Test`, `UpdateSupplierService_Test`, `UpdateSupplierService_FailTest`, `DeleteSupplierService_Test`, `DeleteSupplierService_FailTest`, `GetItemsBySupplierIdService_Test`, `PatchSupplierService_Test`, `PatchSupplierService_FailTest`, and `DeleteSuppliersService_Test`.

Minor changes:

* [`V2/tests/TransferTests.cs`](diffhunk://#diff-f4a787110f79b247e05bd56561626d38b7a00b2c91407fef6d72a92820e5bd8fL749-R749): Added a comment to highlight the next test to be checked.