### PR TITLE
updated the ClientController code coverage

### DIFF
--- a/V2/tests/ClientTests.cs
+++ b/V2/tests/ClientTests.cs
@@ -96,6 +96,28 @@ namespace clients.TestsV2
         }
 
         [TestMethod]
+        public void GetAllClients_Test_returns_NotFound()
+        {
+            //arrange
+            _mockClientService.Setup(_ => _.GetAllClients()).Returns((List<ClientCS>)null);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";
+
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            var result = _clientController.GetAllClients();
+
+            //assert
+            var okResult = result.Result as NotFoundObjectResult;
+            Assert.IsNull(okResult);
+        }
+
+        [TestMethod]
         public void GetClientById_Test_returns_true()
         {
             //arrange
@@ -134,7 +156,28 @@ namespace clients.TestsV2
             Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
 
-        
+        [TestMethod]
+        public void GetClientById_Test_returns_NotFound()
+        {
+            //arrange
+            var client = new ClientCS() { Id = 1, Address = "", City = "", contact_phone = "", contact_email = "", contact_name = "", Country = "", created_at = default, updated_at = default, Name = "", Province = "", zip_code = "" };
+            _mockClientService.Setup(_ => _.GetClientById(2)).Returns((ClientCS)null);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";  
+
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //act
+            var result = _clientController.GetClientById(2);
+
+            //assert
+            var resultok = result.Result as NotFoundObjectResult;
+            Assert.IsNull(resultok);
+        }
 
         [TestMethod]
         public void CreateClient_ReturnsCreatedResult_WithNewClient()
@@ -175,6 +218,26 @@ namespace clients.TestsV2
             var unauthorizedResult = result.Result as UnauthorizedResult;
             Assert.IsNotNull(unauthorizedResult);
             Assert.AreEqual(401, unauthorizedResult.StatusCode);
+        }
+
+        [TestMethod]
+        public void CreateClient_ReturnsCreatedResult_WithoutClient()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin"; 
+
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _clientController.CreateClient(null);
+
+            // Assert
+            var createdResult = result.Result as BadRequestResult;
+            Assert.IsNull(createdResult);
         }
 
         [TestMethod]
@@ -223,6 +286,27 @@ namespace clients.TestsV2
             Assert.IsNotNull(unauthorizedResult);
             Assert.AreEqual(401, unauthorizedResult.StatusCode);
         }
+
+        [TestMethod]
+        public void CreateMultipleClient_ReturnsCreatedResult_WithoutClients()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";
+
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _clientController.CreateMultipleClients(null);
+            var createdResult = result.Result as BadRequestResult;
+
+            // Assert
+            Assert.IsNull(createdResult);
+        }
+            
 
         [TestMethod]
         public void UpdatedClientTest_Success()
@@ -292,6 +376,30 @@ namespace clients.TestsV2
         }
 
         [TestMethod]
+        public void UpdatedClientTest_Failed_BadRequest()
+        {
+            // Arrange
+            var updatedClient = new ClientCS { Address = "street", City = "city", contact_phone = "number", contact_email = "email", contact_name = "name", Country = "Japan", created_at = default, Id = 1, Name = "name", Province = "province", updated_at = default, zip_code = "zip" };
+
+            _mockClientService.Setup(service => service.UpdateClient(0, updatedClient)).Returns((ClientCS)null);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";
+
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _clientController.UpdateClient(1, null);
+
+            // Assert
+            var createdResult = result.Result as BadRequestResult;
+            Assert.IsNull(createdResult);
+        }
+
+        [TestMethod]
         public void DeleteClientTest_Success()
         {
             // Arrange
@@ -323,6 +431,25 @@ namespace clients.TestsV2
             var unauthorizedResult = result as UnauthorizedResult;
             Assert.IsNotNull(unauthorizedResult);
             Assert.AreEqual(401, unauthorizedResult.StatusCode);
+        }
+
+        [TestMethod]
+        public void DeleteClientTest_NotFound()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";
+
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _clientController.DeleteClient(-1);
+            var createdResult = result as NotFoundObjectResult;
+
+            // Assert
+            Assert.IsNull(createdResult);
         }
 
 
@@ -358,6 +485,27 @@ namespace clients.TestsV2
 
             var unauthorizedResult = resultUn as UnauthorizedResult;
             Assert.AreEqual(401, unauthorizedResult.StatusCode);
+        }
+
+        [TestMethod]
+        public void DeleteClientsTest_NotFound()
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";
+
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            //Act
+            var result = _clientController.DeleteClients(null);
+            var createdResult = result as NotFoundObjectResult;
+
+            //Assert
+            Assert.IsNull(createdResult);
+            
         }
 
         [TestMethod]
@@ -401,6 +549,32 @@ namespace clients.TestsV2
             var unauthorizedResult = result.Result as UnauthorizedResult;
             Assert.IsNotNull(unauthorizedResult);
             Assert.AreEqual(401, unauthorizedResult.StatusCode);
+        }
+
+        [TestMethod]
+        public void PatchClientTest_BadRequest()
+        {
+            // Arrange
+            var existingClient = new ClientCS { Id = 1, Address = "old street", City = "old city", contact_phone = "old number", contact_email = "old email", contact_name = "old name", Country = "old country", Name = "old name", Province = "old province", zip_code = "old zip" };
+            var patchClient = new ClientCS { Address = "new street",City = "old city", contact_phone = "old number", contact_email = "old email", contact_name = "old name", Country = "old country", Name = "old name", Province = "old province", zip_code = "old zip" };
+
+            _mockClientService.Setup(service => service.GetClientById(1)).Returns(existingClient);
+            _mockClientService.Setup(service => service.PatchClient(-1, "address", "new street")).Returns((ClientCS)null);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";
+
+            _clientController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _clientController.PatchClient(-1, "address", "new street");
+            var createdResult = result.Result as BadRequestResult;
+
+            // Assert
+           Assert.IsNull(createdResult);
         }
 
         [TestMethod]


### PR DESCRIPTION
This pull request introduces several new test methods to the `V2/tests/ClientTests.cs` file, focusing on handling various error cases for the client-related endpoints. The most important changes include adding tests for `NotFound` and `BadRequest` responses in different scenarios.

New test methods for error handling:

* Added `GetAllClients_Test_returns_NotFound` to handle the case when no clients are found.
* Added `GetClientById_Test_returns_NotFound` to handle the case when a client with a specific ID is not found.
* Added `CreateClient_ReturnsCreatedResult_WithoutClient` to handle the case when a null client is provided.
* Added `CreateMultipleClient_ReturnsCreatedResult_WithoutClients` to handle the case when a null list of clients is provided.
* Added `UpdatedClientTest_Failed_BadRequest` to handle the case when an invalid client update is attempted.
* Added `DeleteClientTest_NotFound` to handle the case when attempting to delete a client with an invalid ID.
* Added `DeleteClientsTest_NotFound` to handle the case when attempting to delete a null list of clients.
* Added `PatchClientTest_BadRequest` to handle the case when an invalid client patch is attempted.