### PR TITLE
542 order service v1 tests coverage

### DIFF
--- a/V1/Cargohub/services/OrderService.cs
+++ b/V1/Cargohub/services/OrderService.cs
@@ -50,7 +50,7 @@ public class OrderService : IOrderService
     {
         List<OrderCS> orders = GetAllOrders();
         List<OrderCS> clientOrders = orders.Where(order => order.ship_to == client_id || order.bill_to == client_id).ToList();
-        if (clientOrders == null)
+        if (clientOrders.Count == 0)
         {
             return null;
         }

--- a/V1/Cargohub/services/OrderService.cs
+++ b/V1/Cargohub/services/OrderService.cs
@@ -61,7 +61,7 @@ public class OrderService : IOrderService
     {
         List<OrderCS> orders = GetAllOrders();
         List<OrderCS> shipmentOrders = orders.Where(order => order.shipment_id == shipmentId).ToList();
-        if (shipmentOrders == null)
+        if (shipmentOrders.Count == 0)
         {
             return null;
         }

--- a/V1/tests/OrderTests.cs
+++ b/V1/tests/OrderTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using ControllersV1;
 using System.Data.Common;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 
 namespace TestsV1
 {
@@ -18,7 +19,39 @@ namespace TestsV1
         {
             _mockOrderService = new Mock<IOrderService>();
             _orderController = new OrderController(_mockOrderService.Object);
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "../../data/orders.json");
+            var order = new OrderCS
+            {
+                Id = 1,
+                source_id = 22,
+                order_date = "2023-10-01T10:00:00Z",
+                request_date = "2023-10-05T10:00:00Z",
+                order_status = "Pending",
+                warehouse_id = 1,
+                ship_to = 1,
+                bill_to = 3,
+                shipment_id = 5,
+                total_amount = 500,
+                total_discount = 50,
+                total_tax = 25,
+                total_surcharge = 10,
+                items = new List<ItemIdAndAmount> { new ItemIdAndAmount { item_id = "1", amount = 10 } }
+            };
+
+            var orderList = new List<OrderCS> { order };
+            var json = JsonConvert.SerializeObject(orderList, Formatting.Indented);
+
+            // Create directory if it does not exist
+            var directory = Path.GetDirectoryName(filePath);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            // Write the JSON data to the file
+            File.WriteAllText(filePath, json);
         }
+
 
         [TestMethod]
         public void GetOrdersTest_Exists()
@@ -237,10 +270,10 @@ namespace TestsV1
         {
             // Arrange
             var items = new List<ItemIdAndAmount>
-    {
-        new ItemIdAndAmount { item_id = "ITEM1", amount = 10 },
-        new ItemIdAndAmount { item_id = "ITEM2", amount = 5 }
-    };
+            {
+                new ItemIdAndAmount { item_id = "ITEM1", amount = 10 },
+                new ItemIdAndAmount { item_id = "ITEM2", amount = 5 }
+            };
             _mockOrderService.Setup(service => service.UpdateOrderItems(1, items)).Returns((OrderCS)null);
 
             // Act
@@ -250,6 +283,196 @@ namespace TestsV1
             Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
             var notFoundResult = result.Result as NotFoundResult;
             Assert.IsNotNull(notFoundResult);
+        }
+
+        // Test for the Service
+        [TestMethod]
+        public void GetAllOrdersService_Test(){
+            var orderService = new OrderService();
+            var orders = orderService.GetAllOrders();
+            Assert.IsNotNull(orders);
+            Assert.AreEqual(1, orders.Count);
+        }
+
+        [TestMethod]
+        public void GetOrdersByIdService_Test(){
+            var orderService = new OrderService();
+            var order = orderService.GetOrderById(1);
+            Assert.IsNotNull(order);
+            Assert.AreEqual("Pending", order.order_status);
+        }
+
+        [TestMethod]
+        public void CreateOrderService_Test(){
+            var order = new OrderCS{
+                Id = 2,
+                source_id = 24,
+                order_date = "2023-10-01T10:00:00Z",
+                request_date = "2023-10-05T10:00:00Z",
+                Reference = "OrderRef123",
+                reference_extra = "ExtraRef",
+                order_status = "Pending",
+                Notes = "Order notes",
+                shipping_notes = "Shipping notes",
+                picking_notes = "Picking notes",
+                warehouse_id = 1,
+                ship_to = 1,
+                bill_to = 3,
+                shipment_id = 5,
+                total_amount = 500,
+                total_discount = 50,
+                total_tax = 25,
+                total_surcharge = 10,
+                created_at = DateTime.UtcNow,
+                updated_at = DateTime.UtcNow,
+                items = new List<ItemIdAndAmount>
+                {
+                    new ItemIdAndAmount { item_id = "ITEM1", amount = 20 },
+                    new ItemIdAndAmount { item_id = "ITEM2", amount = 5 }
+                }
+            };
+            var orderService = new OrderService();
+            var orders = orderService.CreateOrder(order);
+            Assert.IsNotNull(orders);
+            Assert.AreEqual("Pending",orders.order_status);
+
+            var ordersUpdated = orderService.GetAllOrders();
+            Assert.AreEqual(2, ordersUpdated.Count);
+        }
+
+        [TestMethod]
+        public void GetOrdersByClientService_Test(){
+            var orderService = new OrderService();
+            var orders = orderService.GetOrdersByClient(1);
+            Assert.IsNotNull(orders);
+            Assert.AreEqual(1,orders.Count);
+            Assert.AreEqual("Pending",orders[0].order_status);
+        }
+
+        [TestMethod]
+        public void GetOrdersByClientService_Test_Fail(){
+            var orderService = new OrderService();
+            var orders = orderService.GetOrdersByClient(10);
+            Assert.IsNull(orders);
+        }
+
+        [TestMethod]
+        public void GetOrdersByShipmetIdService_Test(){
+            var orderService = new OrderService();
+            var order = orderService.GetOrdersByShipmentId(5);
+            Assert.IsNotNull(order);
+            Assert.AreEqual("Pending", order[0].order_status);
+        }
+
+        [TestMethod]
+        public void GetOrdersByShipmetIdService_Test_Fail(){
+            var orderService = new OrderService();
+            var order = orderService.GetOrdersByShipmentId(10);
+            Assert.AreEqual(0,order.Count);
+        }
+
+        [TestMethod]
+        public void UpdateOrderService_Test(){
+            var order = new OrderCS
+            {
+                Id = 1,
+                source_id = 99,
+                order_date = "2023-10-01T10:00:00Z",
+                request_date = "2023-10-05T10:00:00Z",
+                order_status = "Completed",
+                warehouse_id = 1,
+                ship_to = 1,
+                bill_to = 3,
+                shipment_id = 5,
+                total_amount = 500,
+                total_discount = 50,
+                total_tax = 25,
+                total_surcharge = 10
+            };
+
+            var orderService = new OrderService();
+            var orders = orderService.UpdateOrder(1,order);
+            Assert.IsNotNull(orders);
+            Assert.AreEqual("Completed", orders.order_status);
+        }
+
+        [TestMethod]
+        public void UpdateOrderService_Test_Failed()
+        {
+            var order = new OrderCS
+            {
+                Id = 3,
+                source_id = 99,
+                order_date = "2023-10-01T10:00:00Z",
+                request_date = "2023-10-05T10:00:00Z",
+                order_status = "Completed",
+                warehouse_id = 1,
+                ship_to = 1,
+                bill_to = 3,
+                shipment_id = 5,
+                total_amount = 500,
+                total_discount = 50,
+                total_tax = 25,
+                total_surcharge = 10
+            };
+
+            var orderService = new OrderService();
+            var orders = orderService.UpdateOrder(3,order);
+            Assert.IsNull(orders);
+        }
+        
+        [TestMethod]
+        public void DeleteOrderService_Test()
+        {
+            var orderService = new OrderService();
+            orderService.DeleteOrder(1);
+            var orderUpdated = orderService.GetAllOrders();
+            Assert.AreEqual(0, orderUpdated.Count);
+        }
+
+        [TestMethod]
+        public void DeleteOrderService_Test_failed()
+        {
+            var orderService = new OrderService();
+            orderService.DeleteOrder(3);
+            var orderUpdated = orderService.GetAllOrders();
+            Assert.AreEqual(1, orderUpdated.Count);
+        }
+
+         [TestMethod]
+        public void GetItemsByOrderIdService_Test()
+        {
+            var orderService = new OrderService();
+            var items = orderService.GetItemsByOrderId(1);
+            Assert.IsNotNull(items);
+            Assert.AreEqual("1",items[0].item_id);
+        }
+
+        [TestMethod]
+        public void GetItemsByOrderIdService_Test_Fail()
+        {
+            var orderService = new OrderService();
+            var items = orderService.GetItemsByOrderId(2);
+            Assert.IsNull(items);
+        }
+    
+        [TestMethod]
+        public void UpdateOrderItemsService_Test()
+        {
+            var item = new List<ItemIdAndAmount> { new ItemIdAndAmount { item_id = "2", amount = 20 } };
+            var orderService = new OrderService();
+            var orders = orderService.UpdateOrderItems(1,item);
+            Assert.IsNotNull(orders);
+            Assert.AreEqual("2",orders.items[0].item_id);
+        }
+
+        [TestMethod]
+        public void UpdateOrderItemsService_Test_Fail()
+        {
+            var item = new List<ItemIdAndAmount> { new ItemIdAndAmount { item_id = "2", amount = 20 } };
+            var orderService = new OrderService();
+            var orders = orderService.UpdateOrderItems(2,item);
+            Assert.IsNull(orders);
         }
     }
 }

--- a/V1/tests/OrderTests.cs
+++ b/V1/tests/OrderTests.cs
@@ -368,7 +368,7 @@ namespace TestsV1
         public void GetOrdersByShipmetIdService_Test_Fail(){
             var orderService = new OrderService();
             var order = orderService.GetOrdersByShipmentId(10);
-            Assert.AreEqual(0,order.Count);
+            Assert.IsNull(order);
         }
 
         [TestMethod]

--- a/V2/tests/OrderTests.cs
+++ b/V2/tests/OrderTests.cs
@@ -693,7 +693,6 @@ namespace TestsV2
             var orders = orderService.GetAllOrders();
             Assert.IsNotNull(orders);
             Assert.AreEqual(1, orders.Count);
-
         }
 
         [TestMethod]
@@ -911,6 +910,7 @@ namespace TestsV2
             var orders = orderService.UpdateOrder(3,order);
             Assert.IsNull(orders);
         }
+        
         [TestMethod]
         public void PatchOrderService_Test()
         {


### PR DESCRIPTION
This pull request includes several changes to the `OrderService` and its corresponding tests to improve functionality and test coverage. The most important changes include modifying the `GetOrdersByClient` method, adding new test cases, and updating the test setup to include JSON data.

### Changes to `OrderService`:

* [`V1/Cargohub/services/OrderService.cs`](diffhunk://#diff-f5e0b52d04fb8818808ea4b6ad492db58c30036bcbeda33d1bd44137f2b2b5efL53-R53): Updated the `GetOrdersByClient` method to return `null` only if the `clientOrders` list is empty instead of checking for `null`.

### Changes to test setup:

* [`V1/tests/OrderTests.cs`](diffhunk://#diff-b84f64fdda9d39f7da7b0ae567fe2f8008bf267d9311ea8c02951eb2d26ec589R7): Added the `Newtonsoft.Json` import and updated the `Setup` method to create a JSON file with order data for testing purposes. [[1]](diffhunk://#diff-b84f64fdda9d39f7da7b0ae567fe2f8008bf267d9311ea8c02951eb2d26ec589R7) [[2]](diffhunk://#diff-b84f64fdda9d39f7da7b0ae567fe2f8008bf267d9311ea8c02951eb2d26ec589R22-R55)

### Additions to test cases:

* [`V1/tests/OrderTests.cs`](diffhunk://#diff-b84f64fdda9d39f7da7b0ae567fe2f8008bf267d9311ea8c02951eb2d26ec589R287-R476): Added multiple new test methods to cover various functionalities of the `OrderService`, including `GetAllOrdersService_Test`, `GetOrdersByIdService_Test`, `CreateOrderService_Test`, `GetOrdersByClientService_Test`, `GetOrdersByClientService_Test_Fail`, `GetOrdersByShipmentIdService_Test`, `GetOrdersByShipmentIdService_Test_Fail`, `UpdateOrderService_Test`, `UpdateOrderService_Test_Failed`, `DeleteOrderService_Test`, `DeleteOrderService_Test_failed`, `GetItemsByOrderIdService_Test`, `GetItemsByOrderIdService_Test_Fail`, `UpdateOrderItemsService_Test`, and `UpdateOrderItemsService_Test_Fail`.

### Minor changes to existing tests:

* [`V2/tests/OrderTests.cs`](diffhunk://#diff-fc9ae0990cd6edc53f8471f1381331d42c0ae4d4b3e83917532c70ab3c808966L696): Removed an unnecessary blank line in `GetAllOrdersService_Test` and added a blank line in `UpdateOrderService_Test_Failed` for better readability. [[1]](diffhunk://#diff-fc9ae0990cd6edc53f8471f1381331d42c0ae4d4b3e83917532c70ab3c808966L696) [[2]](diffhunk://#diff-fc9ae0990cd6edc53f8471f1381331d42c0ae4d4b3e83917532c70ab3c808966R913)