### PR TITLE
563 increasing the code coverage for itemtypecontroller 2

### DIFF
--- a/V1/tests/ItemTypeTests.cs
+++ b/V1/tests/ItemTypeTests.cs
@@ -296,5 +296,18 @@ namespace TestsV1
             Assert.AreEqual(updatedItemType, okResult.Value);
         }
 
+        [TestMethod]
+        public async Task UpdateItemType_ItemNotFound_ShouldReturnNotFound()
+        {
+            // Arrange
+            var updatedItemType = new ItemTypeCS { Id = 1, Name = "UpdatedType", description = "UpdatedDescription" };
+            _mockItemTypeService.Setup(service => service.GetItemById(1)).Returns((ItemTypeCS)null);
+
+            // Act
+            var result = await _itemTypeController.UpdateItemType(1, updatedItemType);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
     }
 }

--- a/V1/tests/ItemTypeTests.cs
+++ b/V1/tests/ItemTypeTests.cs
@@ -124,7 +124,7 @@ namespace TestsV1
             // Assert
             Assert.IsNull(result);
         }
-        
+
         [TestMethod]
         public void DeleteItemTypeTest_Exists()
         {
@@ -274,6 +274,41 @@ namespace TestsV1
             Assert.IsNotNull(createdResult);
             Assert.AreEqual(nameof(_itemTypeController.GetItemById), createdResult.ActionName);
             Assert.AreEqual(newItemType.Id, ((ItemTypeCS)createdResult.Value).Id);
+        }
+
+        [TestMethod]
+        public async Task UpdateItemType_ExistingItem_ShouldReturnUpdatedItemType()
+        {
+            // Arrange
+            var existingItemType = new ItemTypeCS { Id = 1, Name = "Type1", description = "Description1" };
+            var updatedItemType = new ItemTypeCS { Id = 1, Name = "UpdatedType", description = "UpdatedDescription" };
+
+            _mockItemTypeService.Setup(service => service.GetItemById(1)).Returns(existingItemType);
+            _mockItemTypeService.Setup(service => service.UpdateItemType(1, updatedItemType)).ReturnsAsync(updatedItemType);
+
+            // Act
+            var result = await _itemTypeController.UpdateItemType(1, updatedItemType);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(OkObjectResult));
+            var okResult = result as OkObjectResult;
+            Assert.IsNotNull(okResult);
+            Assert.AreEqual(updatedItemType, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task UpdateItemType_NonExistingItem_ShouldReturnNotFound()
+        {
+            // Arrange
+            var updatedItemType = new ItemTypeCS { Id = 1, Name = "UpdatedType", description = "UpdatedDescription" };
+
+            _mockItemTypeService.Setup(service => service.GetItemById(1)).Returns((ItemTypeCS)null);
+
+            // Act
+            var result = await _itemTypeController.UpdateItemType(1, updatedItemType);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(NotFoundResult));
         }
 
     }

--- a/V1/tests/ItemTypeTests.cs
+++ b/V1/tests/ItemTypeTests.cs
@@ -113,20 +113,6 @@ namespace TestsV1
         }
 
         [TestMethod]
-        public async Task UpdateItemType_WrongId_ShouldReturnNotFound()
-        {
-            // Arrange
-            var updatedItemType = new ItemTypeCS { Id = 1, Name = "UpdatedType", description = "UpdatedDescription" };
-            _mockItemTypeService.Setup(service => service.UpdateItemType(1, updatedItemType)).ReturnsAsync((ItemTypeCS)null);
-
-            // Act
-            var result = await _itemTypeController.UpdateItemType(1, updatedItemType);
-
-            // Assert
-            Assert.IsInstanceOfType(result, typeof(NotFoundResult));
-        }
-
-        [TestMethod]
         public async Task UpdateItemType_IdMismatch_ShouldReturnBadRequest()
         {
             // Arrange
@@ -138,6 +124,7 @@ namespace TestsV1
             // Assert
             Assert.IsNull(result);
         }
+        
         [TestMethod]
         public void DeleteItemTypeTest_Exists()
         {
@@ -256,6 +243,38 @@ namespace TestsV1
             Assert.AreEqual(0, itemTypesGet2.Count);
         }
 
+        [TestMethod]
+        public async Task CreateItemType_NullItemType_ShouldReturnBadRequest()
+        {
+            // Arrange
+            ItemTypeCS newItemType = null;
+
+            // Act
+            var result = await _itemTypeController.CreateItemType(newItemType);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult));
+            var badRequestResult = result as BadRequestObjectResult;
+            Assert.AreEqual("ItemGroup cannot be null", badRequestResult.Value);
+        }
+
+        [TestMethod]
+        public async Task CreateItemType_ValidItemType_ShouldReturnCreatedItemType()
+        {
+            // Arrange
+            var newItemType = new ItemTypeCS { Id = 3, Name = "Type3", description = "Description3" };
+            _mockItemTypeService.Setup(service => service.CreateItemType(newItemType)).ReturnsAsync(newItemType);
+
+            // Act
+            var result = await _itemTypeController.CreateItemType(newItemType);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(CreatedAtActionResult));
+            var createdResult = result as CreatedAtActionResult;
+            Assert.IsNotNull(createdResult);
+            Assert.AreEqual(nameof(_itemTypeController.GetItemById), createdResult.ActionName);
+            Assert.AreEqual(newItemType.Id, ((ItemTypeCS)createdResult.Value).Id);
+        }
 
     }
 }

--- a/V1/tests/ItemTypeTests.cs
+++ b/V1/tests/ItemTypeTests.cs
@@ -53,10 +53,12 @@ namespace TestsV1
             _mockItemTypeService.Setup(service => service.GetAllItemtypes()).Returns(_itemTypes);
 
             // Act
-            var result = _mockItemTypeService.Object.GetAllItemtypes();
+            var result = _itemTypeController.GetAllItemtypes().Result as OkObjectResult;
+            var itemTypes = result.Value as List<ItemTypeCS>;
 
             // Assert
-            Assert.AreEqual(2, result.Count);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, itemTypes.Count);
         }
 
         [TestMethod]
@@ -67,10 +69,12 @@ namespace TestsV1
             _mockItemTypeService.Setup(service => service.GetItemById(1)).Returns(itemType);
 
             // Act
-            var result = _mockItemTypeService.Object.GetItemById(1);
+            var result = _itemTypeController.GetItemById(1).Result as OkObjectResult;
+            var returnedItemType = result.Value as ItemTypeCS;
 
             // Assert
-            Assert.AreEqual(itemType, result);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(itemType, returnedItemType);
         }
 
         [TestMethod]
@@ -113,13 +117,13 @@ namespace TestsV1
         {
             // Arrange
             var updatedItemType = new ItemTypeCS { Id = 1, Name = "UpdatedType", description = "UpdatedDescription" };
-            _mockItemTypeService.Setup(service => service.GetItemById(1)).Returns((ItemTypeCS)null);
+            _mockItemTypeService.Setup(service => service.UpdateItemType(1, updatedItemType)).ReturnsAsync((ItemTypeCS)null);
 
             // Act
-            var result = await _mockItemTypeService.Object.UpdateItemType(1, updatedItemType);
+            var result = await _itemTypeController.UpdateItemType(1, updatedItemType);
 
             // Assert
-            Assert.IsNull(result);
+            Assert.IsInstanceOfType(result, typeof(NotFoundResult));
         }
 
         [TestMethod]
@@ -238,5 +242,20 @@ namespace TestsV1
             var itemTypesGet = itemTypeService.GetAllItemtypes();
             Assert.AreEqual(1, itemTypesGet.Count);
         }
+
+        [TestMethod]
+        public void DeleteItemTypeService_Test_Empty()
+        {
+            var itemTypeService = new ItemTypeService();
+            itemTypeService.DeleteItemType(1);
+            var itemTypesGet = itemTypeService.GetAllItemtypes();
+            Assert.AreEqual(0, itemTypesGet.Count);
+
+            itemTypeService.DeleteItemType(1);
+            var itemTypesGet2 = itemTypeService.GetAllItemtypes();
+            Assert.AreEqual(0, itemTypesGet2.Count);
+        }
+
+
     }
 }

--- a/V1/tests/ItemTypeTests.cs
+++ b/V1/tests/ItemTypeTests.cs
@@ -290,25 +290,10 @@ namespace TestsV1
             var result = await _itemTypeController.UpdateItemType(1, updatedItemType);
 
             // Assert
-            Assert.IsInstanceOfType(result, typeof(OkObjectResult));
-            var okResult = result as OkObjectResult;
+            Assert.IsInstanceOfType(result, typeof(ActionResult<ItemTypeCS>));
+            var okResult = result.Result as OkObjectResult;
             Assert.IsNotNull(okResult);
             Assert.AreEqual(updatedItemType, okResult.Value);
-        }
-
-        [TestMethod]
-        public async Task UpdateItemType_NonExistingItem_ShouldReturnNotFound()
-        {
-            // Arrange
-            var updatedItemType = new ItemTypeCS { Id = 1, Name = "UpdatedType", description = "UpdatedDescription" };
-
-            _mockItemTypeService.Setup(service => service.GetItemById(1)).Returns((ItemTypeCS)null);
-
-            // Act
-            var result = await _itemTypeController.UpdateItemType(1, updatedItemType);
-
-            // Assert
-            Assert.IsInstanceOfType(result, typeof(NotFoundResult));
         }
 
     }

--- a/V1/tests/ItemTypeTests.cs
+++ b/V1/tests/ItemTypeTests.cs
@@ -309,5 +309,31 @@ namespace TestsV1
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
         }
+
+        [TestMethod]
+        public void GetItemById_ItemNotFound_ShouldReturnNotFound()
+        {
+            // Arrange
+            _mockItemTypeService.Setup(service => service.GetItemById(1)).Returns((ItemTypeCS)null);
+
+            // Act
+            var result = _itemTypeController.GetItemById(1);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public void DeleteItemType_ItemNotFound_ShouldReturnNotFound()
+        {
+            // Arrange
+            _mockItemTypeService.Setup(service => service.GetItemById(1)).Returns((ItemTypeCS)null);
+
+            // Act
+            var result = _itemTypeController.DeleteItemType(1);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(NotFoundResult));
+        }
     }
 }

--- a/V2/tests/ItemTypeTests.cs
+++ b/V2/tests/ItemTypeTests.cs
@@ -429,7 +429,7 @@ namespace itemtype.TestsV2
         [TestMethod]
         public void DeleteItemTypesTest_Failed()
         {
-            
+
             var httpContext = new DefaultHttpContext();
             httpContext.Items["UserRole"] = "Admin";
 
@@ -869,5 +869,100 @@ namespace itemtype.TestsV2
             Assert.AreEqual(newItemType.Name, returnedItemType.Name);
             Assert.AreEqual(newItemType.description, returnedItemType.description);
         }
+
+        [TestMethod]
+        public void GetAllItemtypes_ShouldReturnAllItemTypes_2()
+        {
+            // Arrange
+            _mockItemTypeService.Setup(service => service.GetAllItemtypes()).Returns(_itemTypes);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";
+            _itemTypeController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _itemTypeController.GetAllItemtypes().Result as OkObjectResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(StatusCodes.Status200OK, result.StatusCode);
+            var itemTypes = result.Value as IEnumerable<ItemTypeCS>;
+            Assert.IsNotNull(itemTypes);
+            Assert.AreEqual(2, itemTypes.Count());
+        }
+
+        [TestMethod]
+        public void GetAllItemtypes_ShouldReturnUnauthorized_WhenUserRoleIsInvalid_2()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "HackerMan";
+            _itemTypeController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _itemTypeController.GetAllItemtypes().Result as UnauthorizedResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(StatusCodes.Status401Unauthorized, result.StatusCode);
+        }
+
+        [TestMethod]
+        public void GetItemById_ShouldReturnCorrectItemType_3()
+        {
+            // Arrange
+            var itemType = _itemTypes[0];
+            _mockItemTypeService.Setup(service => service.GetItemById(1)).Returns(itemType);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";
+
+            _itemTypeController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _itemTypeController.GetItemById(1);
+
+            // Assert
+            var okResult = result.Result as OkObjectResult;
+            Assert.IsNotNull(okResult);
+            Assert.AreEqual(StatusCodes.Status200OK, okResult.StatusCode);
+            var returnedItemType = okResult.Value as ItemTypeCS;
+            Assert.IsNotNull(returnedItemType);
+            Assert.AreEqual(itemType.Name, returnedItemType.Name);
+            Assert.AreEqual(itemType.description, returnedItemType.description);
+        }
+
+        [TestMethod]
+        public void GetItemById_ShouldReturnNotFound_WhenItemTypeIsNull_2()
+        {
+            // Arrange
+            _mockItemTypeService.Setup(service => service.GetItemById(1)).Returns((ItemTypeCS)null);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserRole"] = "Admin";
+
+            _itemTypeController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var result = _itemTypeController.GetItemById(1);
+
+            // Assert
+            var notFoundResult = result.Result as NotFoundResult;
+            Assert.IsNotNull(notFoundResult);
+            Assert.AreEqual(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+        }
+
     }
 }


### PR DESCRIPTION
This pull request includes several updates to the test cases in the `V1/tests/ItemTypeTests.cs` and `V2/tests/ItemTypeTests.cs` files to enhance the coverage and accuracy of the tests. The changes include modifications to existing tests, the addition of new tests, and the removal of redundant tests.

### Key Changes:

#### Enhancements to Existing Tests:
* Updated `GetAllItemtypes_ShouldReturnAllItemTypes` to use the controller method and assert the result is not null before checking the count. (`V1/tests/ItemTypeTests.cs`, [V1/tests/ItemTypeTests.csL56-R61](diffhunk://#diff-2ceea928452289a96eabf6fbacabf555e21d5f25354868fad24a94cc5eb9ba7dL56-R61))
* Updated `GetItemById_ShouldReturnCorrectItemType` to use the controller method and assert the result is not null before comparing the returned item. (`V1/tests/ItemTypeTests.cs`, [V1/tests/ItemTypeTests.csL70-R77](diffhunk://#diff-2ceea928452289a96eabf6fbacabf555e21d5f25354868fad24a94cc5eb9ba7dL70-R77))

#### Removal of Redundant Tests:
* Removed the `UpdateItemType_WrongId_ShouldReturnNotFound` test as it was redundant and not necessary. (`V1/tests/ItemTypeTests.cs`, [V1/tests/ItemTypeTests.csL111-L124](diffhunk://#diff-2ceea928452289a96eabf6fbacabf555e21d5f25354868fad24a94cc5eb9ba7dL111-L124))

#### Addition of New Tests:
* Added `DeleteItemTypeService_Test_Empty` to verify the behavior when deleting an item type from an empty service. (`V1/tests/ItemTypeTests.cs`, [V1/tests/ItemTypeTests.csR232-R298](diffhunk://#diff-2ceea928452289a96eabf6fbacabf555e21d5f25354868fad24a94cc5eb9ba7dR232-R298))
* Added `CreateItemType_NullItemType_ShouldReturnBadRequest` to test the creation of a null item type and ensure it returns a bad request. (`V1/tests/ItemTypeTests.cs`, [V1/tests/ItemTypeTests.csR232-R298](diffhunk://#diff-2ceea928452289a96eabf6fbacabf555e21d5f25354868fad24a94cc5eb9ba7dR232-R298))
* Added `CreateItemType_ValidItemType_ShouldReturnCreatedItemType` to test the creation of a valid item type and ensure it returns the created item. (`V1/tests/ItemTypeTests.cs`, [V1/tests/ItemTypeTests.csR232-R298](diffhunk://#diff-2ceea928452289a96eabf6fbacabf555e21d5f25354868fad24a94cc5eb9ba7dR232-R298))
* Added `UpdateItemType_ExistingItem_ShouldReturnUpdatedItemType` to test updating an existing item type and ensure it returns the updated item. (`V1/tests/ItemTypeTests.cs`, [V1/tests/ItemTypeTests.csR232-R298](diffhunk://#diff-2ceea928452289a96eabf6fbacabf555e21d5f25354868fad24a94cc5eb9ba7dR232-R298))

#### New Tests in V2:
* Added `GetAllItemtypes_ShouldReturnAllItemTypes_2` to test the retrieval of all item types with a specific user role. (`V2/tests/ItemTypeTests.cs`, [V2/tests/ItemTypeTests.csR872-R966](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R872-R966))
* Added `GetAllItemtypes_ShouldReturnUnauthorized_WhenUserRoleIsInvalid_2` to test the retrieval of all item types with an invalid user role. (`V2/tests/ItemTypeTests.cs`, [V2/tests/ItemTypeTests.csR872-R966](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R872-R966))
* Added `GetItemById_ShouldReturnCorrectItemType_3` to test the retrieval of an item type by ID with a specific user role. (`V2/tests/ItemTypeTests.cs`, [V2/tests/ItemTypeTests.csR872-R966](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R872-R966))
* Added `GetItemById_ShouldReturnNotFound_WhenItemTypeIsNull_2` to test the retrieval of an item type by ID when the item type is null. (`V2/tests/ItemTypeTests.cs`, [V2/tests/ItemTypeTests.csR872-R966](diffhunk://#diff-5250baebbabfd139dea880ebb6a7d9b34a36c23102c67243a71ad51331624e64R872-R966))