### PR TITLE
558 increase code coverage for itemlineservice

### DIFF
--- a/V1/Cargohub/controllers/ItemLineController.cs
+++ b/V1/Cargohub/controllers/ItemLineController.cs
@@ -38,20 +38,20 @@ public class ItemLineController : ControllerBase
 
     // POST: api/itemLine
     [HttpPost]
-    public async Task<ActionResult<ItemLineCS>> AddItemLine([FromBody] ItemLineCS newItemLine)
+    public ActionResult<ItemLineCS> AddItemLine([FromBody] ItemLineCS newItemLine)
     {
         if (newItemLine == null)
         {
             return BadRequest("ItemLine is null.");
         }
 
-        var createdItemLine = await _itemLineService.AddItemLine(newItemLine);
+        var createdItemLine = _itemLineService.AddItemLine(newItemLine);
         return CreatedAtAction(nameof(GetItemLineById), new { id = createdItemLine.Id }, createdItemLine);
     }
 
     // PUT: api/itemLine/5
     [HttpPut("{id}")]
-    public async Task<ActionResult<ItemLineCS>> UpdateItemLine(int id, [FromBody] ItemLineCS itemLine)
+    public ActionResult<ItemLineCS> UpdateItemLine(int id, [FromBody] ItemLineCS itemLine)
     {
         if (id != itemLine.Id)
         {
@@ -64,7 +64,7 @@ public class ItemLineController : ControllerBase
             return NotFound();
         }
 
-        var updatedItemLine = await _itemLineService.UpdateItemLine(id, itemLine);
+        var updatedItemLine = _itemLineService.UpdateItemLine(id, itemLine);
         return Ok(updatedItemLine);
     }
 

--- a/V1/Cargohub/services/IItemLineServices.cs
+++ b/V1/Cargohub/services/IItemLineServices.cs
@@ -6,8 +6,8 @@ public interface IItemLineService
 {
     List<ItemLineCS> GetAllItemlines();
     ItemLineCS GetItemLineById(int id);
-    Task<ItemLineCS> AddItemLine(ItemLineCS newItemType);
-    Task<ItemLineCS> UpdateItemLine(int id, ItemLineCS itemLine);
+    ItemLineCS AddItemLine(ItemLineCS newItemType);
+    ItemLineCS UpdateItemLine(int id, ItemLineCS itemLine);
     void DeleteItemLine(int id);
     List<ItemCS> GetItemsByItemLineId(int itemlineId);
 }

--- a/V1/Cargohub/services/ItemLineServices.cs
+++ b/V1/Cargohub/services/ItemLineServices.cs
@@ -29,7 +29,7 @@ public class ItemLineService : IItemLineService
         return item;
     }
 
-    public async Task<ItemLineCS> AddItemLine(ItemLineCS newItemLine)
+    public ItemLineCS AddItemLine(ItemLineCS newItemLine)
     {
         List<ItemLineCS> items = GetAllItemlines();
         var currentDateTime = DateTime.Now;
@@ -48,12 +48,12 @@ public class ItemLineService : IItemLineService
         items.Add(newItemLine);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);
-        await File.WriteAllTextAsync(path, jsonData);
+        File.WriteAllText(path, jsonData);
 
         return newItemLine;
     }
 
-    public async Task<ItemLineCS> UpdateItemLine(int id, ItemLineCS itemLine)
+    public ItemLineCS UpdateItemLine(int id, ItemLineCS itemLine)
     {
         List<ItemLineCS> items = GetAllItemlines();
         var existingItem = items.FirstOrDefault(i => i.Id == id);
@@ -71,7 +71,7 @@ public class ItemLineService : IItemLineService
         existingItem.updated_at = DateTime.ParseExact(formattedDateTime, "yyyy-MM-dd HH:mm:ss", null);
 
         var jsonData = JsonConvert.SerializeObject(items, Formatting.Indented);
-        await File.WriteAllTextAsync(path, jsonData);
+        File.WriteAllText(path, jsonData);
 
         return existingItem;
     }


### PR DESCRIPTION
This pull request includes changes to the `ItemLineController`, `ItemLineService`, `IItemLineService`, and related test cases to remove the use of `async` and `await` for synchronous operations. Additionally, it introduces new test cases for better coverage.

Changes to remove `async` and `await`:

* [`V1/Cargohub/controllers/ItemLineController.cs`](diffhunk://#diff-ce256b6fda958e8fd58c7dda35e63a00b472383b9afff3bd653c29eefb4ae02dL41-R54): Modified the `AddItemLine` and `UpdateItemLine` methods to be synchronous by removing `async` and `await`. [[1]](diffhunk://#diff-ce256b6fda958e8fd58c7dda35e63a00b472383b9afff3bd653c29eefb4ae02dL41-R54) [[2]](diffhunk://#diff-ce256b6fda958e8fd58c7dda35e63a00b472383b9afff3bd653c29eefb4ae02dL67-R67)
* [`V1/Cargohub/services/IItemLineServices.cs`](diffhunk://#diff-81b01302f3313217c8ee55894d957fad8c5f849155750356c5f4f721e105aff3L9-R10): Updated the `AddItemLine` and `UpdateItemLine` method signatures to be synchronous.
* [`V1/Cargohub/services/ItemLineServices.cs`](diffhunk://#diff-ece817e49390e4f75430e8939061b6085516dbae8b192d06360203f3979a1bafL32-R32): Changed the `AddItemLine` and `UpdateItemLine` methods to be synchronous by removing `async` and `await`. [[1]](diffhunk://#diff-ece817e49390e4f75430e8939061b6085516dbae8b192d06360203f3979a1bafL32-R32) [[2]](diffhunk://#diff-ece817e49390e4f75430e8939061b6085516dbae8b192d06360203f3979a1bafL51-R56) [[3]](diffhunk://#diff-ece817e49390e4f75430e8939061b6085516dbae8b192d06360203f3979a1bafL74-R74)

Enhancements to test coverage:

* [`V1/tests/ItemLineTests.cs`](diffhunk://#diff-760584338d5b946e31ab06e78e50faca76e60104c140d472622bac8bab05c78eR23-R140): Added new test cases for `GetAllItemlinesService`, `GetItemLineByIdService`, `AddItemLineService`, `UpdateItemLineService`, and `DeleteItemLineService`. [[1]](diffhunk://#diff-760584338d5b946e31ab06e78e50faca76e60104c140d472622bac8bab05c78eR23-R140) [[2]](diffhunk://#diff-760584338d5b946e31ab06e78e50faca76e60104c140d472622bac8bab05c78eL77-R203)
* [`V1/tests/ItemLineTests.cs`](diffhunk://#diff-760584338d5b946e31ab06e78e50faca76e60104c140d472622bac8bab05c78eR8): Modified existing test cases to remove `async` and `await` for synchronous operations. [[1]](diffhunk://#diff-760584338d5b946e31ab06e78e50faca76e60104c140d472622bac8bab05c78eR8) [[2]](diffhunk://#diff-760584338d5b946e31ab06e78e50faca76e60104c140d472622bac8bab05c78eL94-R232) [[3]](diffhunk://#diff-760584338d5b946e31ab06e78e50faca76e60104c140d472622bac8bab05c78eL123-R262) [[4]](diffhunk://#diff-760584338d5b946e31ab06e78e50faca76e60104c140d472622bac8bab05c78eL163) [[5]](diffhunk://#diff-760584338d5b946e31ab06e78e50faca76e60104c140d472622bac8bab05c78eL191)