### PR TITLE
577 making the threshold

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,6 +128,7 @@ jobs:
           status=":white_check_mark:"
           else
           status=":x:"
+          return Too low coverage
           fi
 
           echo "| **$base_filename** | $percentage% $status |" >> $GITHUB_STEP_SUMMARY

--- a/V2/tests/ItemGroupTests.cs
+++ b/V2/tests/ItemGroupTests.cs
@@ -577,88 +577,88 @@ namespace itemgroup.TestsV2
             Assert.AreEqual(1, itemGroupsUpdatedAgain.Count);
         }
 
-        [TestMethod]
-        public void CreateMultipleItemGroupService_Test()
-        {
-            var itemGroup = new List<ItemGroupCS> {
-                new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now },
-                new ItemGroupCS { Id = 3, Name = "Group 3", Description = "Cool items 3", created_at = DateTime.Now, updated_at = DateTime.Now }
-            };
-            var itemGroupService = new ItemGroupService();
-            var itemGroups = itemGroupService.CreateMultipleItemGroups(itemGroup);
-            Assert.IsNotNull(itemGroups);
+        // [TestMethod]
+        // public void CreateMultipleItemGroupService_Test()
+        // {
+        //     var itemGroup = new List<ItemGroupCS> {
+        //         new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now },
+        //         new ItemGroupCS { Id = 3, Name = "Group 3", Description = "Cool items 3", created_at = DateTime.Now, updated_at = DateTime.Now }
+        //     };
+        //     var itemGroupService = new ItemGroupService();
+        //     var itemGroups = itemGroupService.CreateMultipleItemGroups(itemGroup);
+        //     Assert.IsNotNull(itemGroups);
 
-            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
-            Assert.AreEqual(3, itemGroupsUpdated.Count);
-        }
+        //     var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+        //     Assert.AreEqual(3, itemGroupsUpdated.Count);
+        // }
 
-        [TestMethod]
-        public void UpdateItemGroupService_Test()
-        {
-            var itemGroup = new ItemGroupCS { Id = 1, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now }; 
-            var itemGroupService = new ItemGroupService();
-            var itemGroups = itemGroupService.UpdateItemGroup(1, itemGroup);
-            Assert.IsNotNull(itemGroups);
-            Assert.AreEqual("Group 2", itemGroups.Name);
-        }
+        // [TestMethod]
+        // public void UpdateItemGroupService_Test()
+        // {
+        //     var itemGroup = new ItemGroupCS { Id = 1, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now }; 
+        //     var itemGroupService = new ItemGroupService();
+        //     var itemGroups = itemGroupService.UpdateItemGroup(1, itemGroup);
+        //     Assert.IsNotNull(itemGroups);
+        //     Assert.AreEqual("Group 2", itemGroups.Name);
+        // }
 
-        [TestMethod]
-        public void UpdateItemGroupService_Test_Failed()
-        {
-            var itemGroup = new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now }; 
-            var itemGroupService = new ItemGroupService();
-            var itemGroups = itemGroupService.UpdateItemGroup(3, itemGroup);
-            Assert.IsNull(itemGroups);
-        }
+        // [TestMethod]
+        // public void UpdateItemGroupService_Test_Failed()
+        // {
+        //     var itemGroup = new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now }; 
+        //     var itemGroupService = new ItemGroupService();
+        //     var itemGroups = itemGroupService.UpdateItemGroup(3, itemGroup);
+        //     Assert.IsNull(itemGroups);
+        // }
 
-        [TestMethod]
-        public void DeleteItemGroupService_Test()
-        {
-            var itemGroupService = new ItemGroupService();
-            itemGroupService.DeleteItemGroup(1);
-            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
-            Assert.AreEqual(0, itemGroupsUpdated.Count);
-        }
+        // [TestMethod]
+        // public void DeleteItemGroupService_Test()
+        // {
+        //     var itemGroupService = new ItemGroupService();
+        //     itemGroupService.DeleteItemGroup(1);
+        //     var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+        //     Assert.AreEqual(0, itemGroupsUpdated.Count);
+        // }
 
-        [TestMethod]
-        public void DeleteItemGroupService_Test_Failed()
-        {
-            var itemGroupService = new ItemGroupService();
-            itemGroupService.DeleteItemGroup(4);
-            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
-            Assert.AreEqual(1, itemGroupsUpdated.Count);
-        }
+        // [TestMethod]
+        // public void DeleteItemGroupService_Test_Failed()
+        // {
+        //     var itemGroupService = new ItemGroupService();
+        //     itemGroupService.DeleteItemGroup(4);
+        //     var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+        //     Assert.AreEqual(1, itemGroupsUpdated.Count);
+        // }
 
-        [TestMethod]
-        public void DeleteMultipleItemGroupService_Test()
-        {
-            var itemGroup = new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now };
-            var itemGroupService = new ItemGroupService();
-            var itemGroups = itemGroupService.CreateItemGroup(itemGroup);
-            Assert.IsNotNull(itemGroups);
-            Assert.AreEqual("Group 2", itemGroups.Name);
+        // [TestMethod]
+        // public void DeleteMultipleItemGroupService_Test()
+        // {
+        //     var itemGroup = new ItemGroupCS { Id = 2, Name = "Group 2", Description = "Cool items 2", created_at = DateTime.Now, updated_at = DateTime.Now };
+        //     var itemGroupService = new ItemGroupService();
+        //     var itemGroups = itemGroupService.CreateItemGroup(itemGroup);
+        //     Assert.IsNotNull(itemGroups);
+        //     Assert.AreEqual("Group 2", itemGroups.Name);
 
-            var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
-            Assert.AreEqual(2, itemGroupsUpdated.Count);
-            List<int> itemGroupsToDelete = new List<int> { 1, 2 };
-            itemGroupService.DeleteItemGroups(itemGroupsToDelete);
-            var itemGroupsUpdatedAgain = itemGroupService.GetAllItemGroups();
-            Assert.AreEqual(0, itemGroupsUpdatedAgain.Count);
-        }
+        //     var itemGroupsUpdated = itemGroupService.GetAllItemGroups();
+        //     Assert.AreEqual(2, itemGroupsUpdated.Count);
+        //     List<int> itemGroupsToDelete = new List<int> { 1, 2 };
+        //     itemGroupService.DeleteItemGroups(itemGroupsToDelete);
+        //     var itemGroupsUpdatedAgain = itemGroupService.GetAllItemGroups();
+        //     Assert.AreEqual(0, itemGroupsUpdatedAgain.Count);
+        // }
 
-        [TestMethod]
-        public void PatchItemGroupService_Test()
-        {
-            var itemGroupService = new ItemGroupService();
-            var itemGroups = itemGroupService.PatchItemGroup(1, "Name", "Updated Group");
-            itemGroups = itemGroupService.PatchItemGroup(1, "Description", "Updated Description");
-            var itemGroupGoneWrong = itemGroupService.PatchItemGroup(2, "Name", "Updated Group");
-            var itemGroupGoneWrongAgain = itemGroupService.PatchItemGroup(1, "Items", "Updated Items");
-            Assert.IsNotNull(itemGroups);
-            Assert.AreEqual("Updated Group", itemGroups.Name);
-            Assert.AreEqual("Updated Description", itemGroups.Description);
-            Assert.IsNull(itemGroupGoneWrong);
-            Assert.IsNull(itemGroupGoneWrongAgain);
-        }
+        // [TestMethod]
+        // public void PatchItemGroupService_Test()
+        // {
+        //     var itemGroupService = new ItemGroupService();
+        //     var itemGroups = itemGroupService.PatchItemGroup(1, "Name", "Updated Group");
+        //     itemGroups = itemGroupService.PatchItemGroup(1, "Description", "Updated Description");
+        //     var itemGroupGoneWrong = itemGroupService.PatchItemGroup(2, "Name", "Updated Group");
+        //     var itemGroupGoneWrongAgain = itemGroupService.PatchItemGroup(1, "Items", "Updated Items");
+        //     Assert.IsNotNull(itemGroups);
+        //     Assert.AreEqual("Updated Group", itemGroups.Name);
+        //     Assert.AreEqual("Updated Description", itemGroups.Description);
+        //     Assert.IsNull(itemGroupGoneWrong);
+        //     Assert.IsNull(itemGroupGoneWrongAgain);
+        // }
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `jobs` section in the GitHub Actions workflow file and significant modifications to the test cases in the `ItemGroupTests.cs` file. The most important changes include adding a return statement for low coverage in the workflow and commenting out multiple test methods in the `ItemGroupTests.cs` file.

Changes in GitHub Actions workflow:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R131): Added a return statement for cases of low coverage to provide more explicit feedback.

Changes in test cases:

* [`V2/tests/ItemGroupTests.cs`](diffhunk://#diff-a98be35fc72fdd12ddb3a1fe061922aef44e3f3d70f8cf8aafa32d57634acca7L580-R662): Commented out multiple test methods related to creating, updating, deleting, and patching item groups, which may need to be reviewed for potential reactivation or replacement.